### PR TITLE
refactor: remove unused setters from swap handler

### DIFF
--- a/contracts/DCAPair/DCAPairSwapHandler.sol
+++ b/contracts/DCAPair/DCAPairSwapHandler.sol
@@ -23,10 +23,6 @@ interface IDCAPairSwapHandler {
     IERC20Detailed tokenToRewardSwapperWith;
   }
 
-  event OracleSet(ISlidingOracle _oracle);
-
-  event SwapIntervalSet(uint32 _swapInterval);
-
   event Swapped(NextSwapInformation _nextSwapInformation);
 
   function swapInterval() external view returns (uint32);
@@ -55,20 +51,10 @@ abstract contract DCAPairSwapHandler is DCAPairParameters, IDCAPairSwapHandler {
   ISlidingOracle public override oracle;
 
   constructor(ISlidingOracle _oracle, uint32 _swapInterval) {
-    _setOracle(_oracle);
-    _setSwapInterval(_swapInterval);
-  }
-
-  function _setOracle(ISlidingOracle _oracle) internal {
     require(address(_oracle) != address(0), 'DCAPair: zero address');
-    oracle = _oracle;
-    emit OracleSet(_oracle);
-  }
-
-  function _setSwapInterval(uint32 _swapInterval) internal {
     require(_swapInterval >= _MINIMUM_SWAP_INTERVAL, 'DCAPair: interval too short');
+    oracle = _oracle;
     swapInterval = _swapInterval;
-    emit SwapIntervalSet(_swapInterval);
   }
 
   function _addNewRatePerUnit(

--- a/contracts/mocks/DCAPair/DCAPairSwapHandler.sol
+++ b/contracts/mocks/DCAPair/DCAPairSwapHandler.sol
@@ -19,13 +19,6 @@ contract DCAPairSwapHandlerMock is DCAPairSwapHandler, DCAPairParametersMock {
   }
 
   // SwapHandler
-  function setSwapInterval(uint32 _swapInterval) public {
-    _setSwapInterval(_swapInterval);
-  }
-
-  function setOracle(ISlidingOracle _oracle) public {
-    _setOracle(_oracle);
-  }
 
   function registerSwap(
     address _token,

--- a/test/unit/DCAPair/dca-pair-swap-handler.spec.ts
+++ b/test/unit/DCAPair/dca-pair-swap-handler.spec.ts
@@ -82,67 +82,24 @@ describe('DCAPairSwapHandler', () => {
       });
     });
     when('all arguments are valid', () => {
-      it('initizalizes correctly and emits events', async () => {
-        await behaviours.deployShouldSetVariablesAndEmitEvents({
-          contract: DCAPairSwapHandlerContract,
-          args: [
-            tokenA.address,
-            tokenB.address,
-            DCAFactory.address, // factory
-            staticSlidingOracle.address,
-            MINIMUM_SWAP_INTERVAL,
-          ],
-          settersGettersVariablesAndEvents: [
-            {
-              getterFunc: 'swapInterval',
-              variable: MINIMUM_SWAP_INTERVAL,
-              eventEmitted: 'SwapIntervalSet',
-            },
-          ],
-        });
-      });
-    });
-  });
+      let DCAPairSwapHandler: Contract;
 
-  describe('_setOracle', () => {
-    let setOracleTx: Promise<TransactionResponse>;
-    when('oracle is zero address', () => {
       given(async () => {
-        setOracleTx = DCAPairSwapHandler.setOracle(constants.ZERO_ADDRESS);
+        DCAPairSwapHandler = await DCAPairSwapHandlerContract.deploy(
+          tokenA.address,
+          tokenB.address,
+          DCAFactory.address, // factory
+          staticSlidingOracle.address,
+          MINIMUM_SWAP_INTERVAL
+        );
       });
-      then('tx is reverted with reason', async () => {
-        await expect(setOracleTx).to.be.revertedWith('DCAPair: zero address');
-      });
-    });
-    when('oracle is a valid address', () => {
-      let newOracle: string = constants.NOT_ZERO_ADDRESS;
-      given(async () => {
-        setOracleTx = DCAPairSwapHandler.setOracle(newOracle);
-      });
-      then('oracle is set', async () => {
-        expect(await DCAPairSwapHandler.oracle()).to.be.equal(newOracle);
-      });
-      then('event is emitted', async () => {
-        await expect(setOracleTx).to.emit(DCAPairSwapHandler, 'OracleSet').withArgs(newOracle);
-      });
-    });
-  });
 
-  describe('_setSwapInterval', () => {
-    when('swap interval is less than MINIMUM_SWAP_INTERVAL', () => {
-      then('reverts with message', async () => {
-        await expect(DCAPairSwapHandler.setSwapInterval(MINIMUM_SWAP_INTERVAL.sub(1))).to.be.revertedWith('DCAPair: interval too short');
+      it('oracle is set correctly', async () => {
+        expect(await DCAPairSwapHandler.oracle()).to.equal(staticSlidingOracle.address);
       });
-    });
-    when('swap interval is more than MINIMUM_SWAP_INTERVAL', () => {
-      then('sets new value, and emits event with correct args', async () => {
-        await behaviours.txShouldSetVariableAndEmitEvent({
-          contract: DCAPairSwapHandler,
-          getterFunc: 'swapInterval',
-          setterFunc: 'setSwapInterval',
-          variable: MINIMUM_SWAP_INTERVAL,
-          eventEmitted: 'SwapIntervalSet',
-        });
+
+      it('swap interval is set correctly', async () => {
+        expect(await DCAPairSwapHandler.swapInterval()).to.equal(MINIMUM_SWAP_INTERVAL);
       });
     });
   });

--- a/test/unit/utils/collectable-dust.spec.ts
+++ b/test/unit/utils/collectable-dust.spec.ts
@@ -1,4 +1,4 @@
-import { BigNumber, Contract, ContractFactory, utils } from 'ethers';
+import { Contract, ContractFactory, utils } from 'ethers';
 import { ethers } from 'hardhat';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { constants, erc20, wallet } from '../../utils';


### PR DESCRIPTION
We are removing two setters: `_setOracle` and `_setSwapInterval`, since they were only used on the constructor.

At the same time, we are removing the events `OracleSet` and `SwapIntervalSet`, since they were only called once. 