### PR TITLE
fix: apply fee on mocked swap

### DIFF
--- a/test/unit/DCAPair/dca-pair-position-handler.spec.ts
+++ b/test/unit/DCAPair/dca-pair-position-handler.spec.ts
@@ -234,7 +234,7 @@ describe('DCAPositionHandler', () => {
         const swapped = fromEther(RATE_PER_UNIT_5 * POSITION_RATE_5);
         const fee = await getFeeFrom(swapped);
         expect(await tokenB.balanceOf(owner.address)).to.equal(fromEther(INITIAL_TOKEN_B_BALANCE_USER).add(swapped).sub(fee));
-        expect(await tokenB.balanceOf(DCAPositionHandler.address)).to.equal(fromEther(INITIAL_TOKEN_B_BALANCE_CONTRACT));
+        await expectBalanceToBe(tokenB, DCAPositionHandler.address, INITIAL_TOKEN_B_BALANCE_CONTRACT);
       });
 
       then('position is updated', async () => {
@@ -457,8 +457,7 @@ describe('DCAPositionHandler', () => {
         const userBalance = await tokenB.balanceOf(owner.address);
         expect(userBalance).to.be.equal(fromEther(INITIAL_TOKEN_B_BALANCE_USER + swappedWhenTerminated).sub(fee));
 
-        const contractBalance = await tokenB.balanceOf(DCAPositionHandler.address);
-        expect(contractBalance).to.be.equal(fromEther(INITIAL_TOKEN_B_BALANCE_CONTRACT));
+        await expectBalanceToBe(tokenB, DCAPositionHandler.address, INITIAL_TOKEN_B_BALANCE_CONTRACT);
       });
 
       then(`position is removed`, async () => {


### PR DESCRIPTION
When we called `performTrade` to mock a swap, we didn't charge the fee from the amount that was given to the contract. For example, if there were:
* 100 token A to swap
* Rate was 1 token A = 1 token B

We would need to take 100 token A form the contract, and give it `100 token B - 100 token B * 0.3% = 99.7 token B`. We were simply giving it `100 token B`.