### PR TITLE
chore: reduce error msg size

### DIFF
--- a/contracts/DCAFactory/DCAFactoryParameters.sol
+++ b/contracts/DCAFactory/DCAFactoryParameters.sol
@@ -64,7 +64,7 @@ abstract contract DCAFactoryParameters is IDCAFactoryParameters, Governable {
   function addSwapIntervalsToAllowedList(uint32[] calldata _swapIntervals) public override onlyGovernor {
     for (uint256 i = 0; i < _swapIntervals.length; i++) {
       require(_swapIntervals[i] > 0, 'DCAFactory: zero interval');
-      require(!isSwapIntervalAllowed(_swapIntervals[i]), 'DCAFactory: allowed swap interval');
+      require(!isSwapIntervalAllowed(_swapIntervals[i]), 'DCAFactory: already allowed');
       _allowedSwapIntervals.add(_swapIntervals[i]);
     }
     emit SwapIntervalsAllowed(_swapIntervals);
@@ -72,7 +72,7 @@ abstract contract DCAFactoryParameters is IDCAFactoryParameters, Governable {
 
   function removeSwapIntervalsFromAllowedList(uint32[] calldata _swapIntervals) public override onlyGovernor {
     for (uint256 i = 0; i < _swapIntervals.length; i++) {
-      require(isSwapIntervalAllowed(_swapIntervals[i]), 'DCAFactory: swap interval not allowed');
+      require(isSwapIntervalAllowed(_swapIntervals[i]), 'DCAFactory: invalid interval');
       _allowedSwapIntervals.remove(_swapIntervals[i]);
     }
     emit SwapIntervalsForbidden(_swapIntervals);

--- a/contracts/DCAPair/DCAPairSwapHandler.sol
+++ b/contracts/DCAPair/DCAPairSwapHandler.sol
@@ -175,10 +175,7 @@ abstract contract DCAPairSwapHandler is DCAPairParameters, IDCAPairSwapHandler {
       uint256 _balanceAfter = _nextSwapInformation.tokenToBeProvidedBySwapper.balanceOf(address(this));
 
       // Make sure that they sent the tokens back
-      require(
-        _balanceAfter >= _balanceBefore + _nextSwapInformation.amountToBeProvidedBySwapper,
-        'DCAPair: callee did not provide the expected liquidity'
-      );
+      require(_balanceAfter >= _balanceBefore + _nextSwapInformation.amountToBeProvidedBySwapper, 'DCAPair: not enough liquidity');
     } else if (_nextSwapInformation.amountToBeProvidedBySwapper > 0) {
       _nextSwapInformation.tokenToBeProvidedBySwapper.safeTransferFrom(
         msg.sender,

--- a/test/unit/DCAFactory/dca-factory-parameters.spec.ts
+++ b/test/unit/DCAFactory/dca-factory-parameters.spec.ts
@@ -144,25 +144,25 @@ describe('DCAFactoryParameters', function () {
           contract: DCAFactoryParameters,
           func: 'addSwapIntervalsToAllowedList',
           args: [[1, 10]],
-          message: 'DCAFactory: allowed swap interval',
+          message: 'DCAFactory: already allowed',
         });
         await behaviours.txShouldRevertWithMessage({
           contract: DCAFactoryParameters,
           func: 'addSwapIntervalsToAllowedList',
           args: [[1, 11]],
-          message: 'DCAFactory: allowed swap interval',
+          message: 'DCAFactory: already allowed',
         });
         await behaviours.txShouldRevertWithMessage({
           contract: DCAFactoryParameters,
           func: 'addSwapIntervalsToAllowedList',
           args: [[10, 1]],
-          message: 'DCAFactory: allowed swap interval',
+          message: 'DCAFactory: already allowed',
         });
         await behaviours.txShouldRevertWithMessage({
           contract: DCAFactoryParameters,
           func: 'addSwapIntervalsToAllowedList',
           args: [[11, 1]],
-          message: 'DCAFactory: allowed swap interval',
+          message: 'DCAFactory: already allowed',
         });
       });
     });
@@ -195,13 +195,13 @@ describe('DCAFactoryParameters', function () {
           contract: DCAFactoryParameters,
           func: 'removeSwapIntervalsFromAllowedList',
           args: [[1, 2]],
-          message: 'DCAFactory: swap interval not allowed',
+          message: 'DCAFactory: invalid interval',
         });
         await behaviours.txShouldRevertWithMessage({
           contract: DCAFactoryParameters,
           func: 'removeSwapIntervalsFromAllowedList',
           args: [[2, 3]],
-          message: 'DCAFactory: swap interval not allowed',
+          message: 'DCAFactory: invalid interval',
         });
       });
     });

--- a/test/unit/DCAPair/dca-pair-position-handler.spec.ts
+++ b/test/unit/DCAPair/dca-pair-position-handler.spec.ts
@@ -94,7 +94,7 @@ describe('DCAPositionHandler', () => {
           address: tokenA.address,
           rate: 0,
           swaps: POSITION_SWAPS_TO_PERFORM_10,
-          error: 'DCAPair: Invalid rate. It must be positive',
+          error: 'DCAPair: Non-positive rate',
         });
       });
     });
@@ -105,7 +105,7 @@ describe('DCAPositionHandler', () => {
           address: tokenA.address,
           rate: POSITION_RATE_5,
           swaps: 0,
-          error: 'DCAPair: Invalid amount of swaps. It must be positive',
+          error: 'DCAPair: Non-positive amount',
         });
       });
     });
@@ -496,7 +496,7 @@ describe('DCAPositionHandler', () => {
           contract: DCAPositionHandler,
           func: 'modifyRateAndSwaps',
           args: [dcaId, 0, POSITION_SWAPS_TO_PERFORM_10],
-          message: 'DCAPair: Invalid rate. It must be positive',
+          message: 'DCAPair: Non-positive rate',
         });
       });
     });
@@ -509,7 +509,7 @@ describe('DCAPositionHandler', () => {
           contract: DCAPositionHandler,
           func: 'modifyRateAndSwaps',
           args: [dcaId, POSITION_RATE_5, 0],
-          message: 'DCAPair: Invalid amount of swaps. It must be positive',
+          message: 'DCAPair: Non-positive amount',
         });
       });
     });
@@ -605,7 +605,7 @@ describe('DCAPositionHandler', () => {
           contract: DCAPositionHandler,
           func: 'modifySwaps',
           args: [dcaId, 0],
-          message: 'DCAPair: Invalid amount of swaps. It must be positive',
+          message: 'DCAPair: Non-positive amount',
         });
       });
     });
@@ -660,7 +660,7 @@ describe('DCAPositionHandler', () => {
           contract: DCAPositionHandler,
           func: 'addFundsToPosition',
           args: [dcaId, 0, POSITION_SWAPS_TO_PERFORM_10],
-          message: 'DCAPair: The amount to add must be positive',
+          message: 'DCAPair: Non-positive amount',
         });
       });
     });
@@ -697,7 +697,7 @@ describe('DCAPositionHandler', () => {
           contract: DCAPositionHandler,
           func: 'modifyRate',
           args: [dcaId, 0],
-          message: 'DCAPair: Invalid rate. It must be positive',
+          message: 'DCAPair: Non-positive rate',
         });
       });
     });
@@ -745,7 +745,7 @@ describe('DCAPositionHandler', () => {
           contract: DCAPositionHandler,
           func: 'modifyRate',
           args: [dcaId, POSITION_RATE_5 + 1],
-          message: 'DCAPair: You cannot modify only the rate of a position that has already been completed',
+          message: 'DCAPair: Position completed',
         });
       });
     });
@@ -772,7 +772,7 @@ describe('DCAPositionHandler', () => {
       then('tx is reverted', async () => {
         await behaviours.checkTxRevertedWithMessage({
           tx,
-          message: 'DCAPair: Please withdraw before modifying your position, because you might lose some funds otherwise.',
+          message: 'DCAPair: Withdraw before',
         });
       });
     });
@@ -1052,7 +1052,7 @@ describe('DCAPositionHandler', () => {
 
       then('operation is reverted', async () => {
         const result: Promise<TransactionResponse> = execute(DCAPositionHandler.connect(stranger), dcaId);
-        await expect(result).to.be.revertedWith('DCAPair: Called must be owner, or approved by owner');
+        await expect(result).to.be.revertedWith('DCAPair: Caller not allowed');
       });
     });
   }

--- a/test/unit/DCAPair/dca-pair-swap-handler.spec.ts
+++ b/test/unit/DCAPair/dca-pair-swap-handler.spec.ts
@@ -11,7 +11,7 @@ import { readArgFromEvent } from '../../utils/event-utils';
 const MINIMUM_SWAP_INTERVAL = BigNumber.from('60');
 const APPLY_FEE = (bn: BigNumber) => bn.mul(3).div(1000);
 
-describe('DCAPairSwapHandler', () => {
+describe.only('DCAPairSwapHandler', () => {
   let owner: SignerWithAddress;
   let feeRecipient: SignerWithAddress;
   let tokenA: Contract, tokenB: Contract;
@@ -930,7 +930,7 @@ describe('DCAPairSwapHandler', () => {
       });
 
       then('tx is reverted', async () => {
-        await expect(tx).to.be.revertedWith('DCAPair: callee did not provide the expected liquidity');
+        await expect(tx).to.be.revertedWith('DCAPair: not enough liquidity');
       });
 
       then('callee state is not modified', async () => {


### PR DESCRIPTION
We are now making sure that all error messages are 32 chars or less.

We managed to reduce the contract size from 23.44 Kb  to 23.14 Kb.

![image](https://user-images.githubusercontent.com/15222168/119423610-05bb8580-bcda-11eb-89e3-870ca531e416.png)
