### PR TITLE
refactor: move interfaces to its own folder

### DIFF
--- a/contracts/DCAFactory/DCAFactory.sol
+++ b/contracts/DCAFactory/DCAFactory.sol
@@ -4,8 +4,6 @@ pragma solidity 0.8.4;
 import './DCAFactoryParameters.sol';
 import './DCAFactoryPairsHandler.sol';
 
-interface IDCAFactory is IDCAFactoryParameters, IDCAFactoryPairsHandler {}
-
 contract DCAFactory is DCAFactoryParameters, DCAFactoryPairsHandler, IDCAFactory {
   constructor(address _governor, address _feeRecipient) DCAFactoryParameters(_governor, _feeRecipient) {}
 }

--- a/contracts/DCAFactory/DCAFactoryPairsHandler.sol
+++ b/contracts/DCAFactory/DCAFactoryPairsHandler.sol
@@ -2,44 +2,10 @@
 pragma solidity 0.8.4;
 
 import 'hardhat/console.sol';
-
-import '../interfaces/IERC20Detailed.sol';
-
 import '../DCAPair/DCAPair.sol';
-
 import './DCAFactoryParameters.sol';
-
-interface IDCAFactoryPairsHandler is IDCAFactoryParameters {
-  event PairCreated(address indexed _token0, address indexed _token1, uint32 _swapInterval, address _pair);
-
-  function pairByTokensAndSwapInterval(
-    address _tokenA,
-    address _tokenB,
-    uint32 _swapInterval
-  ) external view returns (address _pair);
-
-  function getPairByTokensAndSwapInterval(
-    address _tokenA,
-    address _tokenB,
-    uint32 _swapInterval
-  ) external view returns (address _pair);
-
-  function getPairsByTokens(address _tokenA, address _tokenB) external view returns (address[] memory _pairs);
-
-  function pairsByTokens(
-    address _tokenA,
-    address _tokenB,
-    uint256 _index
-  ) external view returns (address _pair);
-
-  function allPairs(uint256 _pairIndex) external view returns (address pair);
-
-  function createPair(
-    address _tokenA,
-    address _tokenB,
-    uint32 _swapInterval
-  ) external returns (address pair);
-}
+import '../interfaces/IERC20Detailed.sol';
+import '../interfaces/IDCAFactory.sol';
 
 abstract contract DCAFactoryPairsHandler is DCAFactoryParameters, IDCAFactoryPairsHandler {
   mapping(address => mapping(address => mapping(uint32 => address))) public override pairByTokensAndSwapInterval;

--- a/contracts/DCAFactory/DCAFactoryParameters.sol
+++ b/contracts/DCAFactory/DCAFactoryParameters.sol
@@ -3,38 +3,7 @@ pragma solidity 0.8.4;
 
 import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
 import '../utils/Governable.sol';
-
-interface IDCAFactoryParameters {
-  event FeeRecipientSet(address _feeRecipient);
-  event FeeSet(uint32 _feeSet);
-  event SwapIntervalsAllowed(uint32[] _swapIntervals);
-  event SwapIntervalsForbidden(uint32[] _swapIntervals);
-
-  /* Public getters */
-
-  function feeRecipient() external view returns (address);
-
-  function fee() external view returns (uint32);
-
-  // solhint-disable-next-line func-name-mixedcase
-  function FEE_PRECISION() external view returns (uint24);
-
-  // solhint-disable-next-line func-name-mixedcase
-  function MAX_FEE() external view returns (uint32);
-
-  function allowedSwapIntervals() external view returns (uint32[] memory __allowedSwapIntervals); // uint32 is enough for 100 years
-
-  function isSwapIntervalAllowed(uint32 _swapInterval) external view returns (bool);
-
-  /* Public setters */
-  function setFeeRecipient(address _feeRecipient) external;
-
-  function setFee(uint32 _fee) external;
-
-  function addSwapIntervalsToAllowedList(uint32[] calldata _swapIntervals) external;
-
-  function removeSwapIntervalsFromAllowedList(uint32[] calldata _swapIntervals) external;
-}
+import '../interfaces/IDCAFactory.sol';
 
 abstract contract DCAFactoryParameters is IDCAFactoryParameters, Governable {
   using EnumerableSet for EnumerableSet.UintSet;

--- a/contracts/DCAGlobalParameters/DCAGlobalParameters.sol
+++ b/contracts/DCAGlobalParameters/DCAGlobalParameters.sol
@@ -3,37 +3,7 @@ pragma solidity 0.8.4;
 
 import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
 import '../utils/Governable.sol';
-
-interface IDCAGlobalParameters {
-  event FeeRecipientSet(address _feeRecipient);
-  event FeeSet(uint32 _feeSet);
-  event SwapIntervalsAllowed(uint32[] _swapIntervals);
-  event SwapIntervalsForbidden(uint32[] _swapIntervals);
-
-  /* Public getters */
-  function feeRecipient() external view returns (address);
-
-  function fee() external view returns (uint32);
-
-  // solhint-disable-next-line func-name-mixedcase
-  function FEE_PRECISION() external view returns (uint24);
-
-  // solhint-disable-next-line func-name-mixedcase
-  function MAX_FEE() external view returns (uint32);
-
-  function allowedSwapIntervals() external view returns (uint32[] memory __allowedSwapIntervals);
-
-  function isSwapIntervalAllowed(uint32 _swapInterval) external view returns (bool);
-
-  /* Public setters */
-  function setFeeRecipient(address _feeRecipient) external;
-
-  function setFee(uint32 _fee) external;
-
-  function addSwapIntervalsToAllowedList(uint32[] calldata _swapIntervals) external;
-
-  function removeSwapIntervalsFromAllowedList(uint32[] calldata _swapIntervals) external;
-}
+import '../interfaces/IDCAGlobalParameters.sol';
 
 contract DCAGlobalParameters is IDCAGlobalParameters, Governable {
   using EnumerableSet for EnumerableSet.UintSet;

--- a/contracts/DCAPair/DCAPair.sol
+++ b/contracts/DCAPair/DCAPair.sol
@@ -6,8 +6,6 @@ import './DCAPairParameters.sol';
 import './DCAPairPositionHandler.sol';
 import './DCAPairSwapHandler.sol';
 
-interface IDCAPair is IDCAPairParameters, IDCAPairSwapHandler, IDCAPairPositionHandler {}
-
 contract DCAPair is DCAPairParameters, DCAPairSwapHandler, DCAPairPositionHandler, IDCAPair {
   constructor(
     IERC20Detailed _tokenA,

--- a/contracts/DCAPair/DCAPairParameters.sol
+++ b/contracts/DCAPair/DCAPairParameters.sol
@@ -9,41 +9,7 @@ import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 
 import '../DCAFactory/DCAFactory.sol';
 import '../interfaces/IERC20Detailed.sol';
-
-interface IDCAPairParameters {
-  struct DCA {
-    uint32 lastWithdrawSwap;
-    uint32 lastSwap;
-    uint192 rate;
-    bool fromTokenA;
-    uint248 swappedBeforeModified;
-  }
-
-  /* Public getters */
-  function factory() external view returns (IDCAFactory);
-
-  // solhint-disable-next-line func-name-mixedcase
-  function FEE_PRECISION() external view returns (uint24);
-
-  function tokenA() external view returns (IERC20Detailed);
-
-  function tokenB() external view returns (IERC20Detailed);
-
-  function swapAmountDelta(address, uint32) external view returns (int256);
-
-  // TODO: When we reduce contract's size, make this a little bit more useful
-  function userPositions(uint256)
-    external
-    returns (
-      uint32,
-      uint32,
-      uint192,
-      bool,
-      uint248
-    );
-
-  function performedSwaps() external returns (uint32);
-}
+import '../interfaces/IDCAPair.sol';
 
 abstract contract DCAPairParameters is IDCAPairParameters {
   uint24 public constant override FEE_PRECISION = 10000; // TODO: Take from factory in initiation

--- a/contracts/DCAPair/DCAPairPositionHandler.sol
+++ b/contracts/DCAPair/DCAPairPositionHandler.sol
@@ -5,42 +5,6 @@ import './DCAPairParameters.sol';
 import './ERC721/ERC721.sol';
 import '../utils/Math.sol';
 
-interface IDCAPairPositionHandler {
-  event Terminated(address indexed _user, uint256 _dcaId, uint256 _returnedUnswapped, uint256 _returnedSwapped);
-  event Deposited(address indexed _user, uint256 _dcaId, address _fromToken, uint192 _rate, uint32 _startingSwap, uint32 _lastSwap);
-  event Withdrew(address indexed _user, uint256 _dcaId, address _token, uint256 _amount);
-  event WithdrewMany(address indexed _user, uint256[] _dcaIds, uint256 _swappedTokenA, uint256 _swappedTokenB);
-  event Modified(address indexed _user, uint256 _dcaId, uint192 _rate, uint32 _startingSwap, uint32 _lastSwap);
-
-  function deposit(
-    address _tokenAddress,
-    uint192 _rate,
-    uint32 _amountOfSwaps
-  ) external returns (uint256 _dcaId);
-
-  function withdrawSwapped(uint256 _dcaId) external returns (uint256 _swapped);
-
-  function withdrawSwappedMany(uint256[] calldata _dcaIds) external returns (uint256 _swappedTokenA, uint256 _swappedTokenB);
-
-  function modifyRate(uint256 _dcaId, uint192 _newRate) external;
-
-  function modifySwaps(uint256 _dcaId, uint32 _newSwaps) external;
-
-  function modifyRateAndSwaps(
-    uint256 _dcaId,
-    uint192 _newRate,
-    uint32 _newSwaps
-  ) external;
-
-  function addFundsToPosition(
-    uint256 _dcaId,
-    uint256 _amount,
-    uint32 _newSwaps
-  ) external;
-
-  function terminate(uint256 _dcaId) external;
-}
-
 abstract contract DCAPairPositionHandler is DCAPairParameters, IDCAPairPositionHandler, ERC721 {
   using SafeERC20 for IERC20Detailed;
 

--- a/contracts/DCAPair/DCAPairSwapHandler.sol
+++ b/contracts/DCAPair/DCAPairSwapHandler.sol
@@ -8,38 +8,6 @@ import '../interfaces/ISlidingOracle.sol';
 import '../interfaces/IDCAPairSwapCallee.sol';
 import './DCAPairParameters.sol';
 
-interface IDCAPairSwapHandler {
-  struct NextSwapInformation {
-    uint32 swapToPerform;
-    uint256 amountToSwapTokenA;
-    uint256 amountToSwapTokenB;
-    uint256 ratePerUnitBToA;
-    uint256 ratePerUnitAToB;
-    uint256 platformFeeTokenA;
-    uint256 platformFeeTokenB;
-    uint256 amountToBeProvidedBySwapper;
-    uint256 amountToRewardSwapperWith;
-    IERC20Detailed tokenToBeProvidedBySwapper;
-    IERC20Detailed tokenToRewardSwapperWith;
-  }
-
-  event Swapped(NextSwapInformation _nextSwapInformation);
-
-  function swapInterval() external view returns (uint32);
-
-  function lastSwapPerformed() external view returns (uint256);
-
-  function swapAmountAccumulator(address) external view returns (uint256);
-
-  function oracle() external returns (ISlidingOracle);
-
-  function getNextSwapInfo() external view returns (NextSwapInformation memory _nextSwapInformation);
-
-  function swap() external;
-
-  function swap(address _to, bytes calldata _data) external;
-}
-
 abstract contract DCAPairSwapHandler is DCAPairParameters, IDCAPairSwapHandler {
   using SafeERC20 for IERC20Detailed;
 

--- a/contracts/interfaces/IDCAFactory.sol
+++ b/contracts/interfaces/IDCAFactory.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.4;
+
+interface IDCAFactoryParameters {
+  event FeeRecipientSet(address _feeRecipient);
+  event FeeSet(uint32 _feeSet);
+  event SwapIntervalsAllowed(uint32[] _swapIntervals);
+  event SwapIntervalsForbidden(uint32[] _swapIntervals);
+
+  /* Public getters */
+
+  function feeRecipient() external view returns (address);
+
+  function fee() external view returns (uint32);
+
+  // solhint-disable-next-line func-name-mixedcase
+  function FEE_PRECISION() external view returns (uint24);
+
+  // solhint-disable-next-line func-name-mixedcase
+  function MAX_FEE() external view returns (uint32);
+
+  function allowedSwapIntervals() external view returns (uint32[] memory __allowedSwapIntervals); // uint32 is enough for 100 years
+
+  function isSwapIntervalAllowed(uint32 _swapInterval) external view returns (bool);
+
+  /* Public setters */
+  function setFeeRecipient(address _feeRecipient) external;
+
+  function setFee(uint32 _fee) external;
+
+  function addSwapIntervalsToAllowedList(uint32[] calldata _swapIntervals) external;
+
+  function removeSwapIntervalsFromAllowedList(uint32[] calldata _swapIntervals) external;
+}
+
+interface IDCAFactoryPairsHandler is IDCAFactoryParameters {
+  event PairCreated(address indexed _token0, address indexed _token1, uint32 _swapInterval, address _pair);
+
+  function pairByTokensAndSwapInterval(
+    address _tokenA,
+    address _tokenB,
+    uint32 _swapInterval
+  ) external view returns (address _pair);
+
+  function getPairByTokensAndSwapInterval(
+    address _tokenA,
+    address _tokenB,
+    uint32 _swapInterval
+  ) external view returns (address _pair);
+
+  function getPairsByTokens(address _tokenA, address _tokenB) external view returns (address[] memory _pairs);
+
+  function pairsByTokens(
+    address _tokenA,
+    address _tokenB,
+    uint256 _index
+  ) external view returns (address _pair);
+
+  function allPairs(uint256 _pairIndex) external view returns (address pair);
+
+  function createPair(
+    address _tokenA,
+    address _tokenB,
+    uint32 _swapInterval
+  ) external returns (address pair);
+}
+
+interface IDCAFactory is IDCAFactoryParameters, IDCAFactoryPairsHandler {}

--- a/contracts/interfaces/IDCAGlobalParameters.sol
+++ b/contracts/interfaces/IDCAGlobalParameters.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.4;
+
+interface IDCAGlobalParameters {
+  event FeeRecipientSet(address _feeRecipient);
+  event FeeSet(uint32 _feeSet);
+  event SwapIntervalsAllowed(uint32[] _swapIntervals);
+  event SwapIntervalsForbidden(uint32[] _swapIntervals);
+
+  /* Public getters */
+  function feeRecipient() external view returns (address);
+
+  function fee() external view returns (uint32);
+
+  // solhint-disable-next-line func-name-mixedcase
+  function FEE_PRECISION() external view returns (uint24);
+
+  // solhint-disable-next-line func-name-mixedcase
+  function MAX_FEE() external view returns (uint32);
+
+  function allowedSwapIntervals() external view returns (uint32[] memory __allowedSwapIntervals);
+
+  function isSwapIntervalAllowed(uint32 _swapInterval) external view returns (bool);
+
+  /* Public setters */
+  function setFeeRecipient(address _feeRecipient) external;
+
+  function setFee(uint32 _fee) external;
+
+  function addSwapIntervalsToAllowedList(uint32[] calldata _swapIntervals) external;
+
+  function removeSwapIntervalsFromAllowedList(uint32[] calldata _swapIntervals) external;
+}

--- a/contracts/interfaces/IDCAPair.sol
+++ b/contracts/interfaces/IDCAPair.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.4;
+
+import './IDCAFactory.sol';
+import './IERC20Detailed.sol';
+import './ISlidingOracle.sol';
+
+interface IDCAPairParameters {
+  struct DCA {
+    uint32 lastWithdrawSwap;
+    uint32 lastSwap;
+    uint192 rate;
+    bool fromTokenA;
+    uint248 swappedBeforeModified;
+  }
+
+  /* Public getters */
+  function factory() external view returns (IDCAFactory);
+
+  // solhint-disable-next-line func-name-mixedcase
+  function FEE_PRECISION() external view returns (uint24);
+
+  function tokenA() external view returns (IERC20Detailed);
+
+  function tokenB() external view returns (IERC20Detailed);
+
+  function swapAmountDelta(address, uint32) external view returns (int256);
+
+  // TODO: When we reduce contract's size, make this a little bit more useful
+  function userPositions(uint256)
+    external
+    returns (
+      uint32,
+      uint32,
+      uint192,
+      bool,
+      uint248
+    );
+
+  function performedSwaps() external returns (uint32);
+}
+
+interface IDCAPairPositionHandler {
+  event Terminated(address indexed _user, uint256 _dcaId, uint256 _returnedUnswapped, uint256 _returnedSwapped);
+  event Deposited(address indexed _user, uint256 _dcaId, address _fromToken, uint192 _rate, uint32 _startingSwap, uint32 _lastSwap);
+  event Withdrew(address indexed _user, uint256 _dcaId, address _token, uint256 _amount);
+  event WithdrewMany(address indexed _user, uint256[] _dcaIds, uint256 _swappedTokenA, uint256 _swappedTokenB);
+  event Modified(address indexed _user, uint256 _dcaId, uint192 _rate, uint32 _startingSwap, uint32 _lastSwap);
+
+  function deposit(
+    address _tokenAddress,
+    uint192 _rate,
+    uint32 _amountOfSwaps
+  ) external returns (uint256 _dcaId);
+
+  function withdrawSwapped(uint256 _dcaId) external returns (uint256 _swapped);
+
+  function withdrawSwappedMany(uint256[] calldata _dcaIds) external returns (uint256 _swappedTokenA, uint256 _swappedTokenB);
+
+  function modifyRate(uint256 _dcaId, uint192 _newRate) external;
+
+  function modifySwaps(uint256 _dcaId, uint32 _newSwaps) external;
+
+  function modifyRateAndSwaps(
+    uint256 _dcaId,
+    uint192 _newRate,
+    uint32 _newSwaps
+  ) external;
+
+  function addFundsToPosition(
+    uint256 _dcaId,
+    uint256 _amount,
+    uint32 _newSwaps
+  ) external;
+
+  function terminate(uint256 _dcaId) external;
+}
+
+interface IDCAPairSwapHandler {
+  struct NextSwapInformation {
+    uint32 swapToPerform;
+    uint256 amountToSwapTokenA;
+    uint256 amountToSwapTokenB;
+    uint256 ratePerUnitBToA;
+    uint256 ratePerUnitAToB;
+    uint256 platformFeeTokenA;
+    uint256 platformFeeTokenB;
+    uint256 amountToBeProvidedBySwapper;
+    uint256 amountToRewardSwapperWith;
+    IERC20Detailed tokenToBeProvidedBySwapper;
+    IERC20Detailed tokenToRewardSwapperWith;
+  }
+
+  event Swapped(NextSwapInformation _nextSwapInformation);
+
+  function swapInterval() external view returns (uint32);
+
+  function lastSwapPerformed() external view returns (uint256);
+
+  function swapAmountAccumulator(address) external view returns (uint256);
+
+  function oracle() external returns (ISlidingOracle);
+
+  function getNextSwapInfo() external view returns (NextSwapInformation memory _nextSwapInformation);
+
+  function swap() external;
+
+  function swap(address _to, bytes calldata _data) external;
+}
+
+interface IDCAPair is IDCAPairParameters, IDCAPairSwapHandler, IDCAPairPositionHandler {}


### PR DESCRIPTION
We are now simply moving all interfaces from their own file, into the `interfaces` folder