### PR TITLE
refactor: avoid calling external contract

### DIFF
--- a/contracts/DCAPair/DCAPairParameters.sol
+++ b/contracts/DCAPair/DCAPairParameters.sol
@@ -47,6 +47,10 @@ abstract contract DCAPairParameters is IDCAPairParameters {
 
   function _getFeeFromAmount(uint256 _amount) internal view returns (uint256) {
     uint32 _protocolFee = globalParameters.fee();
+    return _getFeeFromAmount(_protocolFee, _amount);
+  }
+
+  function _getFeeFromAmount(uint32 _protocolFee, uint256 _amount) internal pure returns (uint256) {
     (bool _ok, uint256 _fee) = Math.tryMul(_amount, _protocolFee);
     if (_ok) {
       _fee = _fee / FEE_PRECISION / 100;

--- a/contracts/DCAPair/DCAPairSwapHandler.sol
+++ b/contracts/DCAPair/DCAPairSwapHandler.sol
@@ -75,27 +75,32 @@ abstract contract DCAPairSwapHandler is DCAPairParameters, IDCAPairSwapHandler {
     uint256 _amountOfTokenAIfTokenBSwapped =
       _convertTo(_magnitudeB, _nextSwapInformation.amountToSwapTokenB, _nextSwapInformation.ratePerUnitBToA);
 
-    // TODO: We are calling _getFeeFromAmount (which makes a call to the global parameters) a lot. See if we can call the global parameters only once
+    uint32 _protocolFee = globalParameters.fee();
     if (_amountOfTokenAIfTokenBSwapped < _nextSwapInformation.amountToSwapTokenA) {
       _nextSwapInformation.tokenToBeProvidedBySwapper = tokenB;
       _nextSwapInformation.tokenToRewardSwapperWith = tokenA;
       uint256 _tokenASurplus = _nextSwapInformation.amountToSwapTokenA - _amountOfTokenAIfTokenBSwapped;
       _nextSwapInformation.amountToBeProvidedBySwapper = _convertTo(_magnitudeA, _tokenASurplus, _nextSwapInformation.ratePerUnitAToB);
-      _nextSwapInformation.amountToRewardSwapperWith = _tokenASurplus + _getFeeFromAmount(_tokenASurplus);
-      _nextSwapInformation.platformFeeTokenA = _getFeeFromAmount(_amountOfTokenAIfTokenBSwapped);
-      _nextSwapInformation.platformFeeTokenB = _getFeeFromAmount(_nextSwapInformation.amountToSwapTokenB);
+      _nextSwapInformation.amountToRewardSwapperWith = _tokenASurplus + _getFeeFromAmount(_protocolFee, _tokenASurplus);
+      _nextSwapInformation.platformFeeTokenA = _getFeeFromAmount(_protocolFee, _amountOfTokenAIfTokenBSwapped);
+      _nextSwapInformation.platformFeeTokenB = _getFeeFromAmount(_protocolFee, _nextSwapInformation.amountToSwapTokenB);
     } else if (_amountOfTokenAIfTokenBSwapped > _nextSwapInformation.amountToSwapTokenA) {
       _nextSwapInformation.tokenToBeProvidedBySwapper = tokenA;
       _nextSwapInformation.tokenToRewardSwapperWith = tokenB;
       _nextSwapInformation.amountToBeProvidedBySwapper = _amountOfTokenAIfTokenBSwapped - _nextSwapInformation.amountToSwapTokenA;
       uint256 _amountToBeProvidedConvertedToB =
         _convertTo(_magnitudeA, _nextSwapInformation.amountToBeProvidedBySwapper, _nextSwapInformation.ratePerUnitAToB);
-      _nextSwapInformation.amountToRewardSwapperWith = _amountToBeProvidedConvertedToB + _getFeeFromAmount(_amountToBeProvidedConvertedToB);
-      _nextSwapInformation.platformFeeTokenA = _getFeeFromAmount(_nextSwapInformation.amountToSwapTokenA);
-      _nextSwapInformation.platformFeeTokenB = _getFeeFromAmount(_nextSwapInformation.amountToSwapTokenB - _amountToBeProvidedConvertedToB);
+      _nextSwapInformation.amountToRewardSwapperWith =
+        _amountToBeProvidedConvertedToB +
+        _getFeeFromAmount(_protocolFee, _amountToBeProvidedConvertedToB);
+      _nextSwapInformation.platformFeeTokenA = _getFeeFromAmount(_protocolFee, _nextSwapInformation.amountToSwapTokenA);
+      _nextSwapInformation.platformFeeTokenB = _getFeeFromAmount(
+        _protocolFee,
+        _nextSwapInformation.amountToSwapTokenB - _amountToBeProvidedConvertedToB
+      );
     } else {
-      _nextSwapInformation.platformFeeTokenA = _getFeeFromAmount(_nextSwapInformation.amountToSwapTokenA);
-      _nextSwapInformation.platformFeeTokenB = _getFeeFromAmount(_nextSwapInformation.amountToSwapTokenB);
+      _nextSwapInformation.platformFeeTokenA = _getFeeFromAmount(_protocolFee, _nextSwapInformation.amountToSwapTokenA);
+      _nextSwapInformation.platformFeeTokenB = _getFeeFromAmount(_protocolFee, _nextSwapInformation.amountToSwapTokenB);
     }
   }
 


### PR DESCRIPTION
We are making a simple and small change to avoid calling the `globalParameters` external contract so much during the swap.  We will now only call it once to calculate the protocol fee.

The avg gas for `swap` went from `225911` to `224016`. The improvement is small, but the "overhead" is non-existent and everything helps, right? If you disagree, please let me know