### PR TITLE
feat: make global params pausable

### DIFF
--- a/contracts/DCAGlobalParameters/DCAGlobalParameters.sol
+++ b/contracts/DCAGlobalParameters/DCAGlobalParameters.sol
@@ -84,6 +84,10 @@ contract DCAGlobalParameters is IDCAGlobalParameters, Governable, Pausable {
     return _allowedSwapIntervals.contains(_swapInterval);
   }
 
+  function paused() public view override(IDCAGlobalParameters, Pausable) returns (bool) {
+    return super.paused();
+  }
+
   function pause() public override onlyGovernor {
     _pause();
   }

--- a/contracts/interfaces/IDCAGlobalParameters.sol
+++ b/contracts/interfaces/IDCAGlobalParameters.sol
@@ -32,6 +32,8 @@ interface IDCAGlobalParameters {
 
   function isSwapIntervalAllowed(uint32 _swapInterval) external view returns (bool);
 
+  function paused() external returns (bool);
+
   /* Public setters */
   function setFeeRecipient(address _feeRecipient) external;
 

--- a/test/unit/DCAGlobalParameters/dca-global-parameters.spec.ts
+++ b/test/unit/DCAGlobalParameters/dca-global-parameters.spec.ts
@@ -6,7 +6,7 @@ import { ethers } from 'hardhat';
 import { constants, behaviours, bn } from '../../utils';
 import { given, then, when } from '../../utils/bdd';
 
-describe('DCAGlobalParameters', function () {
+describe('DCAGlobalParameters', () => {
   let owner: SignerWithAddress, feeRecipient: SignerWithAddress, nftDescriptor: SignerWithAddress;
   let DCAGlobalParametersContract: ContractFactory;
   let DCAGlobalParameters: Contract;


### PR DESCRIPTION
We are now making the global params contract pausable. This won't have any effect on the global params contract itself, but the idea is that it will prevent users from executing flash loans/swaps on our pair contracts.

The part on the pair contracts is done in https://github.com/Mean-Finance/dca/pull/40