### PR TITLE
refactor: move positions to position handler

### DIFF
--- a/contracts/DCAPair/DCAPairParameters.sol
+++ b/contracts/DCAPair/DCAPairParameters.sol
@@ -24,7 +24,6 @@ abstract contract DCAPairParameters is IDCAPairParameters {
 
   // Tracking
   mapping(address => mapping(uint32 => int256)) public override swapAmountDelta;
-  mapping(uint256 => DCA) public override userPositions;
   uint32 public override performedSwaps; // Note: If we had swaps every minute, for 100 years, uint32 would still cover it
   mapping(address => mapping(uint32 => uint256[2])) internal _accumRatesPerUnit;
   mapping(address => uint256) internal _balances;

--- a/contracts/interfaces/IDCAPair.sol
+++ b/contracts/interfaces/IDCAPair.sol
@@ -6,14 +6,6 @@ import './IERC20Detailed.sol';
 import './ISlidingOracle.sol';
 
 interface IDCAPairParameters {
-  struct DCA {
-    uint32 lastWithdrawSwap;
-    uint32 lastSwap;
-    uint192 rate;
-    bool fromTokenA;
-    uint248 swappedBeforeModified;
-  }
-
   /* Public getters */
   function globalParameters() external view returns (IDCAGlobalParameters);
 
@@ -23,26 +15,25 @@ interface IDCAPairParameters {
 
   function swapAmountDelta(address, uint32) external view returns (int256);
 
-  // TODO: When we reduce contract's size, make this a little bit more useful
-  function userPositions(uint256)
-    external
-    returns (
-      uint32,
-      uint32,
-      uint192,
-      bool,
-      uint248
-    );
-
-  function performedSwaps() external returns (uint32);
+  function performedSwaps() external view returns (uint32);
 }
 
 interface IDCAPairPositionHandler {
+  struct DCA {
+    uint32 lastWithdrawSwap;
+    uint32 lastSwap;
+    uint192 rate;
+    bool fromTokenA;
+    uint248 swappedBeforeModified;
+  }
+
   event Terminated(address indexed _user, uint256 _dcaId, uint256 _returnedUnswapped, uint256 _returnedSwapped);
   event Deposited(address indexed _user, uint256 _dcaId, address _fromToken, uint192 _rate, uint32 _startingSwap, uint32 _lastSwap);
   event Withdrew(address indexed _user, uint256 _dcaId, address _token, uint256 _amount);
   event WithdrewMany(address indexed _user, uint256[] _dcaIds, uint256 _swappedTokenA, uint256 _swappedTokenB);
   event Modified(address indexed _user, uint256 _dcaId, uint192 _rate, uint32 _startingSwap, uint32 _lastSwap);
+
+  function userPosition(uint256) external view returns (DCA memory);
 
   function deposit(
     address _tokenAddress,

--- a/test/unit/DCAPair/dca-pair-position-handler.spec.ts
+++ b/test/unit/DCAPair/dca-pair-position-handler.spec.ts
@@ -816,7 +816,7 @@ describe('DCAPositionHandler', () => {
       });
 
       then('position is modified correctly', async () => {
-        const { swappedBeforeModified } = await DCAPositionHandler.userPositions(dcaId);
+        const { swappedBeforeModified } = await DCAPositionHandler.userPosition(dcaId);
         expect(swappedBeforeModified).to.equal(MAX);
       });
     });
@@ -1255,7 +1255,7 @@ describe('DCAPositionHandler', () => {
       rate: positionRate,
       lastWithdrawSwap: positionLastWithdrawSwap,
       lastSwap: positionLastSwap,
-    } = await DCAPositionHandler.userPositions(dcaId);
+    } = await DCAPositionHandler.userPosition(dcaId);
     const fromAddress = typeof from === 'string' ? from : from.address;
     expect(fromTokenA, 'Wrong from address in position').to.equal(tokenA.address === fromAddress);
     expect(positionRate, 'Wrong rate').to.equal(fromTokenA ? tokenA.asUnits(rate) : tokenB.asUnits(rate));


### PR DESCRIPTION
We are simply moving the user positions mapping from the pair parameters contract to the position handler. 

Also, we renamed the function `userPositions` to `userPosition`, which makes a little bit more sense