### PR TITLE
test: fix mocks to not use swap interval by default

### DIFF
--- a/contracts/DCAFactory/DCAFactoryPairsHandler.sol
+++ b/contracts/DCAFactory/DCAFactoryPairsHandler.sol
@@ -7,8 +7,7 @@ import '../interfaces/IDCAFactory.sol';
 import '../interfaces/IDCAGlobalParameters.sol';
 
 abstract contract DCAFactoryPairsHandler is IDCAFactoryPairsHandler {
-  mapping(address => mapping(address => mapping(uint32 => address))) public override pairByTokensAndSwapInterval;
-  mapping(address => mapping(address => address[])) public override pairsByTokens;
+  mapping(address => mapping(address => address)) internal _pairByTokens; // token0 => token1 => pair
   address[] public override allPairs;
   IDCAGlobalParameters public override globalParameters;
 
@@ -21,36 +20,19 @@ abstract contract DCAFactoryPairsHandler is IDCAFactoryPairsHandler {
     (_token0, _token1) = _tokenA < _tokenB ? (_tokenA, _tokenB) : (_tokenB, _tokenA);
   }
 
-  function getPairByTokensAndSwapInterval(
-    address _tokenA,
-    address _tokenB,
-    uint32 _swapInterval
-  ) external view override returns (address _pair) {
+  function pairByTokens(address _tokenA, address _tokenB) external view override returns (address _pair) {
     (address _token0, address _token1) = _sortTokens(_tokenA, _tokenB);
-    _pair = pairByTokensAndSwapInterval[_token0][_token1][_swapInterval];
+    _pair = _pairByTokens[_token0][_token1];
   }
 
-  function getPairsByTokens(address _tokenA, address _tokenB) external view override returns (address[] memory) {
-    (address _token0, address _token1) = _sortTokens(_tokenA, _tokenB);
-    return pairsByTokens[_token0][_token1];
-  }
-
-  function createPair(
-    address _tokenA,
-    address _tokenB,
-    uint32 _swapInterval
-  ) public override returns (address _pair) {
-    require(globalParameters.isSwapIntervalAllowed(_swapInterval), 'DCAFactory: interval not allowed');
+  function createPair(address _tokenA, address _tokenB) public override returns (address _pair) {
     require(_tokenA != address(0) && _tokenB != address(0), 'DCAFactory: zero address');
     require(_tokenA != _tokenB, 'DCAFactory: identical addresses');
     (address _token0, address _token1) = _sortTokens(_tokenA, _tokenB);
-    require(pairByTokensAndSwapInterval[_token0][_token1][_swapInterval] == address(0), 'DCAFactory: pair exists');
-    _pair = address(
-      new DCAPair(globalParameters, ISlidingOracle(address(0xe)), IERC20Detailed(_token0), IERC20Detailed(_token1), _swapInterval)
-    );
-    pairByTokensAndSwapInterval[_token0][_token1][_swapInterval] = _pair;
-    pairsByTokens[_token0][_token1].push(_pair);
+    require(_pairByTokens[_token0][_token1] == address(0), 'DCAFactory: pair exists');
+    _pair = address(new DCAPair(globalParameters, ISlidingOracle(address(0xe)), IERC20Detailed(_token0), IERC20Detailed(_token1)));
+    _pairByTokens[_token0][_token1] = _pair;
     allPairs.push(_pair);
-    emit PairCreated(_token0, _token1, _swapInterval, _pair);
+    emit PairCreated(_token0, _token1, _pair);
   }
 }

--- a/contracts/DCAPair/DCAPair.sol
+++ b/contracts/DCAPair/DCAPair.sol
@@ -12,7 +12,6 @@ contract DCAPair is DCAPairParameters, DCAPairSwapHandler, DCAPairPositionHandle
     IDCAGlobalParameters _globalParameters,
     ISlidingOracle _oracle,
     IERC20Detailed _tokenA,
-    IERC20Detailed _tokenB,
-    uint32 _swapInterval
-  ) DCAPairParameters(_globalParameters, _tokenA, _tokenB, _swapInterval) DCAPairSwapHandler(_oracle) DCAPairPositionHandler(_tokenA, _tokenB) {}
+    IERC20Detailed _tokenB
+  ) DCAPairParameters(_globalParameters, _tokenA, _tokenB) DCAPairSwapHandler(_oracle) DCAPairPositionHandler(_tokenA, _tokenB) {}
 }

--- a/contracts/DCAPair/DCAPairParameters.sol
+++ b/contracts/DCAPair/DCAPairParameters.sol
@@ -19,7 +19,6 @@ abstract contract DCAPairParameters is IDCAPairParameters {
   IDCAGlobalParameters public override globalParameters;
   IERC20Detailed public override tokenA;
   IERC20Detailed public override tokenB;
-  uint32 public override swapInterval;
 
   // Tracking
   mapping(uint32 => mapping(address => mapping(uint32 => int256))) public override swapAmountDelta; // swap interval => from token => swap number => delta
@@ -30,8 +29,7 @@ abstract contract DCAPairParameters is IDCAPairParameters {
   constructor(
     IDCAGlobalParameters _globalParameters,
     IERC20Detailed _tokenA,
-    IERC20Detailed _tokenB,
-    uint32 _swapInterval
+    IERC20Detailed _tokenB
   ) {
     require(address(_globalParameters) != address(0), 'DCAPair: zero address');
     require(address(_tokenA) != address(0), 'DCAPair: zero address');
@@ -42,7 +40,6 @@ abstract contract DCAPairParameters is IDCAPairParameters {
     tokenB = _tokenB;
     _magnitudeA = 10**_tokenA.decimals();
     _magnitudeB = 10**_tokenB.decimals();
-    swapInterval = _swapInterval;
   }
 
   function _getFeeFromAmount(uint32 _feeAmount, uint256 _amount) internal view returns (uint256) {

--- a/contracts/DCAPair/DCAPairPositionHandler.sol
+++ b/contracts/DCAPair/DCAPairPositionHandler.sol
@@ -27,7 +27,7 @@ abstract contract DCAPairPositionHandler is ReentrancyGuard, DCAPairParameters, 
     uint32 _swapInterval
   ) public override nonReentrant returns (uint256) {
     require(_tokenAddress == address(tokenA) || _tokenAddress == address(tokenB), 'DCAPair: invalid deposit address');
-    // TODO: validate that swap interval is allowed
+    require(globalParameters.isSwapIntervalAllowed(_swapInterval), 'DCAPair: interval not allowed');
     IERC20Detailed _from = _tokenAddress == address(tokenA) ? tokenA : tokenB;
     uint256 _amount = _rate * _amountOfSwaps;
     _from.safeTransferFrom(msg.sender, address(this), _amount);
@@ -35,7 +35,7 @@ abstract contract DCAPairPositionHandler is ReentrancyGuard, DCAPairParameters, 
     _idCounter += 1;
     _safeMint(msg.sender, _idCounter);
     (uint32 _startingSwap, uint32 _finalSwap) = _addPosition(_idCounter, _tokenAddress, _rate, _amountOfSwaps, 0, _swapInterval);
-    emit Deposited(msg.sender, _idCounter, _tokenAddress, _rate, _startingSwap, _finalSwap);
+    emit Deposited(msg.sender, _idCounter, _tokenAddress, _rate, _startingSwap, _swapInterval, _finalSwap);
     return _idCounter;
   }
 

--- a/contracts/DCAPair/DCAPairSwapHandler.sol
+++ b/contracts/DCAPair/DCAPairSwapHandler.sol
@@ -24,35 +24,46 @@ abstract contract DCAPairSwapHandler is ReentrancyGuard, DCAPairParameters, IDCA
   }
 
   function _addNewRatePerUnit(
+    uint32 _swapInterval,
     address _address,
     uint32 _performedSwap,
     uint256 _ratePerUnit
   ) internal {
     uint32 _previousSwap = _performedSwap - 1;
-    uint256[2] memory _accumRatesPerUnitPreviousSwap = _accumRatesPerUnit[swapInterval][_address][_previousSwap];
+    uint256[2] memory _accumRatesPerUnitPreviousSwap = _accumRatesPerUnit[_swapInterval][_address][_previousSwap];
     (bool _ok, uint256 _result) = Math.tryAdd(_accumRatesPerUnitPreviousSwap[0], _ratePerUnit);
     if (_ok) {
-      _accumRatesPerUnit[swapInterval][_address][_performedSwap] = [_result, _accumRatesPerUnitPreviousSwap[1]];
+      _accumRatesPerUnit[_swapInterval][_address][_performedSwap] = [_result, _accumRatesPerUnitPreviousSwap[1]];
     } else {
       uint256 _missingUntilOverflow = type(uint256).max - _accumRatesPerUnitPreviousSwap[0];
-      _accumRatesPerUnit[swapInterval][_address][_performedSwap] = [_ratePerUnit - _missingUntilOverflow, _accumRatesPerUnitPreviousSwap[1] + 1];
+      _accumRatesPerUnit[_swapInterval][_address][_performedSwap] = [
+        _ratePerUnit - _missingUntilOverflow,
+        _accumRatesPerUnitPreviousSwap[1] + 1
+      ];
     }
   }
 
   function _registerSwap(
+    uint32 _swapInterval,
     address _token,
     uint256 _internalAmountUsedToSwap,
     uint256 _ratePerUnit,
     uint32 _swapToRegister
   ) internal {
-    swapAmountAccumulator[swapInterval][_token] = _internalAmountUsedToSwap;
-    _addNewRatePerUnit(_token, _swapToRegister, _ratePerUnit);
-    delete swapAmountDelta[swapInterval][_token][_swapToRegister];
+    swapAmountAccumulator[_swapInterval][_token] = _internalAmountUsedToSwap;
+    _addNewRatePerUnit(_swapInterval, _token, _swapToRegister, _ratePerUnit);
+    delete swapAmountDelta[_swapInterval][_token][_swapToRegister];
   }
 
-  function _getAmountToSwap(address _address, uint32 _swapToPerform) internal view returns (uint256 _swapAmountAccumulator) {
+  function _getAmountToSwap(
+    uint32 _swapInterval,
+    address _address,
+    uint32 _swapToPerform
+  ) internal view returns (uint256 _swapAmountAccumulator) {
     unchecked {
-      _swapAmountAccumulator = swapAmountAccumulator[swapInterval][_address] + uint256(swapAmountDelta[swapInterval][_address][_swapToPerform]);
+      _swapAmountAccumulator =
+        swapAmountAccumulator[_swapInterval][_address] +
+        uint256(swapAmountDelta[_swapInterval][_address][_swapToPerform]);
     }
   }
 
@@ -64,15 +75,15 @@ abstract contract DCAPairSwapHandler is ReentrancyGuard, DCAPairParameters, IDCA
     _amountTo = (_amountFrom * _rateFromTo) / _fromTokenMagnitude;
   }
 
-  function getNextSwapInfo() public view override returns (NextSwapInformation memory _nextSwapInformation) {
+  function getNextSwapInfo(uint32 _swapInterval) public view override returns (NextSwapInformation memory _nextSwapInformation) {
     uint32 _swapFee = globalParameters.swapFee();
-    _nextSwapInformation = _getNextSwapInfo(_swapFee);
+    _nextSwapInformation = _getNextSwapInfo(_swapInterval, _swapFee);
   }
 
-  function _getNextSwapInfo(uint32 _swapFee) internal view returns (NextSwapInformation memory _nextSwapInformation) {
-    _nextSwapInformation.swapToPerform = performedSwaps[swapInterval] + 1;
-    _nextSwapInformation.amountToSwapTokenA = _getAmountToSwap(address(tokenA), _nextSwapInformation.swapToPerform);
-    _nextSwapInformation.amountToSwapTokenB = _getAmountToSwap(address(tokenB), _nextSwapInformation.swapToPerform);
+  function _getNextSwapInfo(uint32 _swapInterval, uint32 _swapFee) internal view returns (NextSwapInformation memory _nextSwapInformation) {
+    _nextSwapInformation.swapToPerform = performedSwaps[_swapInterval] + 1;
+    _nextSwapInformation.amountToSwapTokenA = _getAmountToSwap(_swapInterval, address(tokenA), _nextSwapInformation.swapToPerform);
+    _nextSwapInformation.amountToSwapTokenB = _getAmountToSwap(_swapInterval, address(tokenB), _nextSwapInformation.swapToPerform);
     // TODO: Instead of using current, it should use quote to get a moving average and not current?
     _nextSwapInformation.ratePerUnitBToA = oracle.current(address(tokenB), _magnitudeB, address(tokenA));
     _nextSwapInformation.ratePerUnitAToB = (_magnitudeB * _magnitudeA) / _nextSwapInformation.ratePerUnitBToA;
@@ -114,11 +125,12 @@ abstract contract DCAPairSwapHandler is ReentrancyGuard, DCAPairParameters, IDCA
     }
   }
 
-  function swap() public override {
-    swap(0, 0, msg.sender, '');
+  function swap(uint32 _swapInterval) public override {
+    swap(_swapInterval, 0, 0, msg.sender, '');
   }
 
   function swap(
+    uint32 _swapInterval,
     uint256 _amountToBorrowTokenA,
     uint256 _amountToBorrowTokenB,
     address _to,
@@ -126,22 +138,24 @@ abstract contract DCAPairSwapHandler is ReentrancyGuard, DCAPairParameters, IDCA
   ) public override nonReentrant {
     IDCAGlobalParameters.SwapParameters memory _swapParameters = globalParameters.swapParameters();
     require(!_swapParameters.isPaused, 'DCAPair: swaps are paused');
-    require(lastSwapPerformed[swapInterval] / swapInterval < _getTimestamp() / swapInterval, 'DCAPair: within interval slot');
-    NextSwapInformation memory _nextSwapInformation = _getNextSwapInfo(_swapParameters.swapFee);
+    require(lastSwapPerformed[_swapInterval] / _swapInterval < _getTimestamp() / _swapInterval, 'DCAPair: within interval slot');
+    NextSwapInformation memory _nextSwapInformation = _getNextSwapInfo(_swapInterval, _swapParameters.swapFee);
     _registerSwap(
+      _swapInterval,
       address(tokenA),
       _nextSwapInformation.amountToSwapTokenA,
       _nextSwapInformation.ratePerUnitAToB,
       _nextSwapInformation.swapToPerform
     );
     _registerSwap(
+      _swapInterval,
       address(tokenB),
       _nextSwapInformation.amountToSwapTokenB,
       _nextSwapInformation.ratePerUnitBToA,
       _nextSwapInformation.swapToPerform
     );
-    performedSwaps[swapInterval] = _nextSwapInformation.swapToPerform;
-    lastSwapPerformed[swapInterval] = block.timestamp;
+    performedSwaps[_swapInterval] = _nextSwapInformation.swapToPerform;
+    lastSwapPerformed[_swapInterval] = block.timestamp;
     require(
       _amountToBorrowTokenA <= _nextSwapInformation.availableToBorrowTokenA &&
         _amountToBorrowTokenB <= _nextSwapInformation.availableToBorrowTokenB,

--- a/contracts/interfaces/IDCAFactory.sol
+++ b/contracts/interfaces/IDCAFactory.sol
@@ -4,37 +4,15 @@ pragma solidity 0.8.4;
 import './IDCAGlobalParameters.sol';
 
 interface IDCAFactoryPairsHandler {
-  event PairCreated(address indexed _token0, address indexed _token1, uint32 _swapInterval, address _pair);
+  event PairCreated(address indexed _token0, address indexed _token1, address _pair);
 
   function globalParameters() external view returns (IDCAGlobalParameters);
 
-  function pairByTokensAndSwapInterval(
-    address _tokenA,
-    address _tokenB,
-    uint32 _swapInterval
-  ) external view returns (address _pair);
-
-  function getPairByTokensAndSwapInterval(
-    address _tokenA,
-    address _tokenB,
-    uint32 _swapInterval
-  ) external view returns (address _pair);
-
-  function getPairsByTokens(address _tokenA, address _tokenB) external view returns (address[] memory _pairs);
-
-  function pairsByTokens(
-    address _tokenA,
-    address _tokenB,
-    uint256 _index
-  ) external view returns (address _pair);
+  function pairByTokens(address _tokenA, address _tokenB) external view returns (address _pair);
 
   function allPairs(uint256 _pairIndex) external view returns (address pair);
 
-  function createPair(
-    address _tokenA,
-    address _tokenB,
-    uint32 _swapInterval
-  ) external returns (address pair);
+  function createPair(address _tokenA, address _tokenB) external returns (address pair);
 }
 
 interface IDCAFactory is IDCAFactoryPairsHandler {}

--- a/contracts/interfaces/IDCAPair.sol
+++ b/contracts/interfaces/IDCAPair.sol
@@ -20,8 +20,6 @@ interface IDCAPairParameters {
   ) external view returns (int256);
 
   function performedSwaps(uint32) external view returns (uint32);
-
-  function swapInterval() external view returns (uint32);
 }
 
 interface IDCAPairPositionHandler {
@@ -35,7 +33,15 @@ interface IDCAPairPositionHandler {
   }
 
   event Terminated(address indexed _user, uint256 _dcaId, uint256 _returnedUnswapped, uint256 _returnedSwapped);
-  event Deposited(address indexed _user, uint256 _dcaId, address _fromToken, uint192 _rate, uint32 _startingSwap, uint32 _lastSwap); // TODO: add swap interval
+  event Deposited(
+    address indexed _user,
+    uint256 _dcaId,
+    address _fromToken,
+    uint192 _rate,
+    uint32 _startingSwap,
+    uint32 _swapInterval,
+    uint32 _lastSwap
+  );
   event Withdrew(address indexed _user, uint256 _dcaId, address _token, uint256 _amount);
   event WithdrewMany(address indexed _user, uint256[] _dcaIds, uint256 _swappedTokenA, uint256 _swappedTokenB);
   event Modified(address indexed _user, uint256 _dcaId, uint192 _rate, uint32 _startingSwap, uint32 _lastSwap);
@@ -103,11 +109,12 @@ interface IDCAPairSwapHandler {
 
   function oracle() external returns (ISlidingOracle);
 
-  function getNextSwapInfo() external view returns (NextSwapInformation memory _nextSwapInformation);
+  function getNextSwapInfo(uint32 _swapInterval) external view returns (NextSwapInformation memory _nextSwapInformation);
 
-  function swap() external;
+  function swap(uint32 _swapInterval) external;
 
   function swap(
+    uint32 _swapInterval,
     uint256 _amountToBorrowTokenA,
     uint256 _amountToBorrowTokenB,
     address _to,

--- a/contracts/mocks/DCAFactory/DCAFactoryPairsHandler.sol
+++ b/contracts/mocks/DCAFactory/DCAFactoryPairsHandler.sol
@@ -7,7 +7,7 @@ import '../../DCAFactory/DCAFactoryPairsHandler.sol';
 contract DCAFactoryPairsHandlerMock is DCAFactoryPairsHandler {
   constructor(IDCAGlobalParameters _globalParameters) DCAFactoryPairsHandler(_globalParameters) {}
 
-  function sortTokens(address _tokenA, address _tokenB) public pure returns (address _token0, address _token1) {
-    (_token0, _token1) = _sortTokens(_tokenA, _tokenB);
-  }
+  // function sortTokens(address _tokenA, address _tokenB) public pure returns (address _token0, address _token1) {
+  //   (_token0, _token1) = _sortTokens(_tokenA, _tokenB);
+  // }
 }

--- a/contracts/mocks/DCAPair/DCAPairLoanHandler.sol
+++ b/contracts/mocks/DCAPair/DCAPairLoanHandler.sol
@@ -9,5 +9,5 @@ contract DCAPairLoanHandlerMock is DCAPairLoanHandler, DCAPairParametersMock {
     IERC20Detailed _token0,
     IERC20Detailed _token1,
     IDCAGlobalParameters _globalParameters
-  ) DCAPairParametersMock(_globalParameters, _token0, _token1, 0) {}
+  ) DCAPairParametersMock(_globalParameters, _token0, _token1) {}
 }

--- a/contracts/mocks/DCAPair/DCAPairParameters.sol
+++ b/contracts/mocks/DCAPair/DCAPairParameters.sol
@@ -8,9 +8,8 @@ contract DCAPairParametersMock is DCAPairParameters {
   constructor(
     IDCAGlobalParameters _globalParameters,
     IERC20Detailed _tokenA,
-    IERC20Detailed _tokenB,
-    uint32 _swapInterval
-  ) DCAPairParameters(_globalParameters, _tokenA, _tokenB, _swapInterval) {}
+    IERC20Detailed _tokenB
+  ) DCAPairParameters(_globalParameters, _tokenA, _tokenB) {}
 
   // Mocks setters
 

--- a/contracts/mocks/DCAPair/DCAPairPositionHandler.sol
+++ b/contracts/mocks/DCAPair/DCAPairPositionHandler.sol
@@ -10,7 +10,7 @@ contract DCAPairPositionHandlerMock is DCAPairPositionHandler, DCAPairParameters
     IDCAGlobalParameters _globalParameters,
     IERC20Detailed _tokenA,
     IERC20Detailed _tokenB
-  ) DCAPairParametersMock(_globalParameters, _tokenA, _tokenB, 0) DCAPairPositionHandler(_tokenA, _tokenB) {
+  ) DCAPairParametersMock(_globalParameters, _tokenA, _tokenB) DCAPairPositionHandler(_tokenA, _tokenB) {
     /* */
   }
 

--- a/contracts/mocks/DCAPair/DCAPairSwapHandler.sol
+++ b/contracts/mocks/DCAPair/DCAPairSwapHandler.sol
@@ -12,25 +12,29 @@ contract DCAPairSwapHandlerMock is DCAPairSwapHandler, DCAPairParametersMock {
     IERC20Detailed _token0,
     IERC20Detailed _token1,
     IDCAGlobalParameters _globalParameters,
-    ISlidingOracle _oracle,
-    uint32 _swapInterval
-  ) DCAPairParametersMock(_globalParameters, _token0, _token1, _swapInterval) DCAPairSwapHandler(_oracle) {
+    ISlidingOracle _oracle
+  ) DCAPairParametersMock(_globalParameters, _token0, _token1) DCAPairSwapHandler(_oracle) {
     /* */
   }
 
   // SwapHandler
 
   function registerSwap(
+    uint32 _swapInterval,
     address _token,
     uint256 _internalAmountUsedToSwap,
     uint256 _ratePerUnit,
     uint32 _swapToRegister
   ) public {
-    _registerSwap(_token, _internalAmountUsedToSwap, _ratePerUnit, _swapToRegister);
+    _registerSwap(_swapInterval, _token, _internalAmountUsedToSwap, _ratePerUnit, _swapToRegister);
   }
 
-  function getAmountToSwap(address _tokenAddress, uint32 _swap) public view returns (uint256) {
-    return _getAmountToSwap(_tokenAddress, _swap);
+  function getAmountToSwap(
+    uint32 _swapInterval,
+    address _tokenAddress,
+    uint32 _swap
+  ) public view returns (uint256) {
+    return _getAmountToSwap(_swapInterval, _tokenAddress, _swap);
   }
 
   function setBlockTimestamp(uint256 _blockTimestamp) public {
@@ -44,11 +48,12 @@ contract DCAPairSwapHandlerMock is DCAPairSwapHandler, DCAPairParametersMock {
   // Mocks setters
 
   function addNewRatePerUnit(
+    uint32 _swapInterval,
     address _tokenAddress,
     uint32 _swap,
     uint256 _ratePerUnit
   ) public {
-    _addNewRatePerUnit(_tokenAddress, _swap, _ratePerUnit);
+    _addNewRatePerUnit(_swapInterval, _tokenAddress, _swap, _ratePerUnit);
   }
 
   function setSwapAmountAccumulator(

--- a/test/e2e/DCAPair/reentrancy-guard.spec.ts
+++ b/test/e2e/DCAPair/reentrancy-guard.spec.ts
@@ -52,13 +52,8 @@ contract('DCAPair', () => {
       });
       staticSlidingOracle = await staticSlidingOracleContract.deploy(0, 0);
       DCAGlobalParameters = await DCAGlobalParametersFactory.deploy(governor.address, feeRecipient.address, constants.NOT_ZERO_ADDRESS);
-      DCAPair = await DCAPairFactory.deploy(
-        DCAGlobalParameters.address,
-        staticSlidingOracle.address,
-        tokenA.address,
-        tokenB.address,
-        swapInterval
-      );
+      DCAPair = await DCAPairFactory.deploy(DCAGlobalParameters.address, staticSlidingOracle.address, tokenA.address, tokenB.address);
+      await DCAGlobalParameters.addSwapIntervalsToAllowedList([swapInterval], ['NULL']);
     });
 
     describe('loan', () => {
@@ -102,8 +97,8 @@ contract('DCAPair', () => {
       });
 
       testReentrantForFunction({
-        funcAndSignature: 'swap(uint256,uint256,address,bytes)',
-        args: () => [0, 0, reentrantDCAPairSwapCallee.address, utils.formatBytes32String('')],
+        funcAndSignature: 'swap(uint32,uint256,uint256,address,bytes)',
+        args: () => [swapInterval, 0, 0, reentrantDCAPairSwapCallee.address, utils.formatBytes32String('')],
         attackerContract: () => reentrantDCAPairSwapCallee,
       });
     });
@@ -211,7 +206,7 @@ contract('DCAPair', () => {
         funcAndSignature,
         args,
         attackerContract,
-        attack: async () => (await DCAPair.populateTransaction['swap()']()).data!,
+        attack: async () => (await DCAPair.populateTransaction['swap(uint32)'](0)).data!,
       });
 
       testReentrantAttack({
@@ -220,7 +215,7 @@ contract('DCAPair', () => {
         args,
         attackerContract,
         attack: async () =>
-          (await DCAPair.populateTransaction['swap(uint256,uint256,address,bytes)'](0, 0, constants.NOT_ZERO_ADDRESS, '0x')).data!,
+          (await DCAPair.populateTransaction['swap(uint32,uint256,uint256,address,bytes)'](0, 0, 0, constants.NOT_ZERO_ADDRESS, '0x')).data!,
       });
 
       testReentrantAttack({

--- a/test/unit/DCAFactory/dca-factory-pairs-handler.spec.ts
+++ b/test/unit/DCAFactory/dca-factory-pairs-handler.spec.ts
@@ -6,7 +6,7 @@ import { constants, erc20, behaviours } from '../../utils';
 import { given, then, when } from '../../utils/bdd';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
-describe.skip('DCAFactoryPairsHandler', function () {
+describe('DCAFactoryPairsHandler', function () {
   let owner: SignerWithAddress;
   let tokenA: Contract, tokenB: Contract;
   let DCAGlobalParametersContract: ContractFactory, DCAFactoryPairsHandlerContract: ContractFactory;
@@ -56,26 +56,12 @@ describe.skip('DCAFactoryPairsHandler', function () {
     });
   });
   describe('createPair', () => {
-    const allowedIntervals = [1000];
-    given(async () => {
-      await DCAGlobalParameters.addSwapIntervalsToAllowedList(allowedIntervals, ['description']);
-    });
-    when('swap interval is not allowed', () => {
-      then('tx is reverted with reason', async () => {
-        await behaviours.txShouldRevertWithMessage({
-          contract: DCAFactoryPairsHandler,
-          func: 'createPair',
-          args: [tokenA.address, tokenB.address, 1],
-          message: 'DCAFactory: interval not allowed',
-        });
-      });
-    });
     when('token A is zero address', () => {
       then('tx is reverted with reason', async () => {
         await behaviours.txShouldRevertWithZeroAddress({
           contract: DCAFactoryPairsHandler,
           func: 'createPair',
-          args: [constants.ZERO_ADDRESS, tokenB.address, allowedIntervals[0]],
+          args: [constants.ZERO_ADDRESS, tokenB.address],
         });
       });
     });
@@ -84,7 +70,7 @@ describe.skip('DCAFactoryPairsHandler', function () {
         await behaviours.txShouldRevertWithZeroAddress({
           contract: DCAFactoryPairsHandler,
           func: 'createPair',
-          args: [tokenA.address, constants.ZERO_ADDRESS, allowedIntervals[0]],
+          args: [tokenA.address, constants.ZERO_ADDRESS],
         });
       });
     });
@@ -93,21 +79,21 @@ describe.skip('DCAFactoryPairsHandler', function () {
         await behaviours.txShouldRevertWithMessage({
           contract: DCAFactoryPairsHandler,
           func: 'createPair',
-          args: [tokenA.address, tokenA.address, allowedIntervals[0]],
+          args: [tokenA.address, tokenA.address],
           message: 'DCAFactory: identical addresses',
         });
       });
     });
     when('pair already exists', () => {
       given(async () => {
-        await DCAFactoryPairsHandler.createPair(tokenA.address, tokenB.address, allowedIntervals[0]);
+        await DCAFactoryPairsHandler.createPair(tokenA.address, tokenB.address);
       });
       when('sending tokenA first', () => {
         then('tx is reverted with reason', async () => {
           await behaviours.txShouldRevertWithMessage({
             contract: DCAFactoryPairsHandler,
             func: 'createPair',
-            args: [tokenA.address, tokenB.address, allowedIntervals[0]],
+            args: [tokenA.address, tokenB.address],
             message: 'DCAFactory: pair exists',
           });
         });
@@ -117,7 +103,7 @@ describe.skip('DCAFactoryPairsHandler', function () {
           await behaviours.txShouldRevertWithMessage({
             contract: DCAFactoryPairsHandler,
             func: 'createPair',
-            args: [tokenB.address, tokenA.address, allowedIntervals[0]],
+            args: [tokenB.address, tokenA.address],
             message: 'DCAFactory: pair exists',
           });
         });
@@ -127,90 +113,74 @@ describe.skip('DCAFactoryPairsHandler', function () {
       let hipotheticPairAddress: string;
       let createPairTx: TransactionResponse;
       given(async () => {
-        hipotheticPairAddress = await DCAFactoryPairsHandler.callStatic.createPair(tokenA.address, tokenB.address, allowedIntervals[0]);
-        createPairTx = await DCAFactoryPairsHandler.createPair(tokenA.address, tokenB.address, allowedIntervals[0]);
+        hipotheticPairAddress = await DCAFactoryPairsHandler.callStatic.createPair(tokenA.address, tokenB.address);
+        createPairTx = await DCAFactoryPairsHandler.createPair(tokenA.address, tokenB.address);
       });
       then('creates pair with correct information', async () => {
         const dcaPair = await ethers.getContractAt('contracts/DCAPair/DCAPair.sol:DCAPair', hipotheticPairAddress);
         expect(await dcaPair.globalParameters()).to.equal(DCAGlobalParameters.address);
       });
       then('adds it to the registry', async () => {
-        expect(await DCAFactoryPairsHandler.getPairByTokensAndSwapInterval(tokenA.address, tokenB.address, allowedIntervals[0])).to.equal(
-          hipotheticPairAddress
-        );
-        expect(await DCAFactoryPairsHandler.getPairsByTokens(tokenA.address, tokenB.address)).to.eql([hipotheticPairAddress]);
+        expect(await DCAFactoryPairsHandler.pairByTokens(tokenA.address, tokenB.address)).to.equal(hipotheticPairAddress);
+        expect(await DCAFactoryPairsHandler.pairByTokens(tokenA.address, tokenB.address)).to.equal(hipotheticPairAddress);
         expect(await DCAFactoryPairsHandler.allPairs(0)).to.equal(hipotheticPairAddress);
       });
       then('emits event', async () => {
         const { token0, token1 } = sortTokens(tokenA.address, tokenB.address);
-        await expect(createPairTx)
-          .to.emit(DCAFactoryPairsHandler, 'PairCreated')
-          .withArgs(token0, token1, allowedIntervals[0], hipotheticPairAddress);
+        await expect(createPairTx).to.emit(DCAFactoryPairsHandler, 'PairCreated').withArgs(token0, token1, hipotheticPairAddress);
       });
     });
   });
 
-  describe('getPairsByTokens', () => {
-    when('there are no pairs for tokenA<->tokenB', () => {
-      then('returns empty array', async () => {
-        expect(await DCAFactoryPairsHandler.getPairsByTokens(tokenA.address, tokenB.address)).to.be.empty;
+  describe('pairByTokens', () => {
+    when('pair for tokenA<->tokenB doesnt exist', () => {
+      then('zero address', async () => {
+        expect(await DCAFactoryPairsHandler.pairByTokens(tokenA.address, tokenB.address)).to.equal(constants.ZERO_ADDRESS);
       });
     });
-    when('there are pairs for tokenA<->tokenB', () => {
+    when('pair for tokenA<->tokenB exists', () => {
       let hipotheticPairAddress: string;
       given(async () => {
-        await DCAGlobalParameters.addSwapIntervalsToAllowedList([1000], ['description']);
-        hipotheticPairAddress = await DCAFactoryPairsHandler.callStatic.createPair(tokenA.address, tokenB.address, 1000);
-        await DCAFactoryPairsHandler.createPair(tokenA.address, tokenB.address, 1000);
+        hipotheticPairAddress = await DCAFactoryPairsHandler.callStatic.createPair(tokenA.address, tokenB.address);
+        await DCAFactoryPairsHandler.createPair(tokenA.address, tokenB.address);
       });
-      then('returns correct array of addresses', async () => {
+      then('returns correct pair address', async () => {
         const { token0, token1 } = sortTokens(tokenA.address, tokenB.address);
-        expect(await DCAFactoryPairsHandler.getPairsByTokens(token0, token1)).to.eql([hipotheticPairAddress]);
+        expect(await DCAFactoryPairsHandler.pairByTokens(token0, token1)).to.equal(hipotheticPairAddress);
       });
-      then('returns same array of addresses if asking for tokenB<->tokenA pairs', async () => {
-        expect(await DCAFactoryPairsHandler.getPairsByTokens(tokenA.address, tokenB.address)).to.eql(
-          await DCAFactoryPairsHandler.getPairsByTokens(tokenB.address, tokenA.address)
+      then('returns the same address if asking for tokenB<->tokenA pair', async () => {
+        expect(await DCAFactoryPairsHandler.pairByTokens(tokenA.address, tokenB.address)).to.equal(
+          await DCAFactoryPairsHandler.pairByTokens(tokenB.address, tokenA.address)
         );
       });
     });
   });
 
-  describe('getPairByTokensAndSwapInterval', () => {
-    when('there is no pair for tokenA<->tokenB and swap interval', () => {
-      then('returns empty address', async () => {
-        expect(await DCAFactoryPairsHandler.getPairByTokensAndSwapInterval(tokenA.address, tokenB.address, 100)).to.be.equal(
-          constants.ZERO_ADDRESS
-        );
+  describe.skip('sortTokens', () => {
+    when('sorting token addresses', () => {
+      let token0: string;
+      let token1: string;
+      given(async () => {
+        [token0, token1] = await DCAFactoryPairsHandler.sortTokens(tokenA.address, tokenB.address);
+      });
+      then('token0 is correct', () => {
+        expect(sortTokens(tokenA.address, tokenB.address).token0).to.equal(token0);
+      });
+      then('token1 is correct', () => {
+        expect(sortTokens(tokenA.address, tokenB.address).token1).to.equal(token1);
       });
     });
-    when('there is a pair for tokenA<->tokenB but is another interval', () => {
-      const swapInterval = 1000;
+    when('calling with inverted order', () => {
+      let token0: string;
+      let token1: string;
       given(async () => {
-        await DCAGlobalParameters.addSwapIntervalsToAllowedList([swapInterval], ['description']);
-        await DCAFactoryPairsHandler.createPair(tokenA.address, tokenB.address, swapInterval);
+        [token0, token1] = await DCAFactoryPairsHandler.sortTokens(tokenA.address, tokenB.address);
       });
-      then('returns empty address', async () => {
-        expect(await DCAFactoryPairsHandler.getPairByTokensAndSwapInterval(tokenA.address, tokenB.address, swapInterval + 1)).to.be.equal(
-          constants.ZERO_ADDRESS
-        );
+      then('token0 is the same', async () => {
+        await expect((await DCAFactoryPairsHandler.sortTokens(tokenA.address, tokenB.address))[0]).to.equal(token0);
       });
-    });
-    when('there is a pair for tokenA<->tokenB and swap interval', () => {
-      const swapInterval = 1000;
-      let hipotheticPairAddress: string;
-      given(async () => {
-        await DCAGlobalParameters.addSwapIntervalsToAllowedList([swapInterval], ['description']);
-        hipotheticPairAddress = await DCAFactoryPairsHandler.callStatic.createPair(tokenA.address, tokenB.address, swapInterval);
-        await DCAFactoryPairsHandler.createPair(tokenA.address, tokenB.address, swapInterval);
-      });
-      then('returns correct address', async () => {
-        const { token0, token1 } = sortTokens(tokenA.address, tokenB.address);
-        expect(await DCAFactoryPairsHandler.getPairByTokensAndSwapInterval(token0, token1, swapInterval)).to.be.equal(hipotheticPairAddress);
-      });
-      then('returns same address if asking for tokenB<->tokenA and same swap interval', async () => {
-        expect(await DCAFactoryPairsHandler.getPairByTokensAndSwapInterval(tokenA.address, tokenB.address, swapInterval)).to.be.equal(
-          await DCAFactoryPairsHandler.getPairByTokensAndSwapInterval(tokenB.address, tokenA.address, swapInterval)
-        );
+      then('token1 is the same', async () => {
+        await expect((await DCAFactoryPairsHandler.sortTokens(tokenA.address, tokenB.address))[1]).to.equal(token1);
       });
     });
   });

--- a/test/unit/DCAPair/dca-pair-parameters.spec.ts
+++ b/test/unit/DCAPair/dca-pair-parameters.spec.ts
@@ -36,7 +36,7 @@ describe('DCAPairParameters', function () {
       initialAmount: utils.parseEther('1'),
     });
     DCAGlobalParameters = await DCAGlobalParametersContract.deploy(owner.address, constants.NOT_ZERO_ADDRESS, constants.NOT_ZERO_ADDRESS);
-    DCAPairParameters = await DCAPairParametersContract.deploy(DCAGlobalParameters.address, tokenA.address, tokenB.address, 0);
+    DCAPairParameters = await DCAPairParametersContract.deploy(DCAGlobalParameters.address, tokenA.address, tokenB.address);
   });
 
   describe('constructor', () => {
@@ -44,7 +44,7 @@ describe('DCAPairParameters', function () {
       then('deployment is reverted with reason', async () => {
         await behaviours.deployShouldRevertWithZeroAddress({
           contract: DCAPairParametersContract,
-          args: [constants.ZERO_ADDRESS, tokenA.address, tokenB.address, 0],
+          args: [constants.ZERO_ADDRESS, tokenA.address, tokenB.address],
         });
       });
     });
@@ -52,7 +52,7 @@ describe('DCAPairParameters', function () {
       then('deployment is reverted with reason', async () => {
         await behaviours.deployShouldRevertWithZeroAddress({
           contract: DCAPairParametersContract,
-          args: [constants.NOT_ZERO_ADDRESS, constants.ZERO_ADDRESS, tokenB.address, 0],
+          args: [constants.NOT_ZERO_ADDRESS, constants.ZERO_ADDRESS, tokenB.address],
         });
       });
     });
@@ -60,7 +60,7 @@ describe('DCAPairParameters', function () {
       then('deployment is reverted with reason', async () => {
         await behaviours.deployShouldRevertWithZeroAddress({
           contract: DCAPairParametersContract,
-          args: [constants.NOT_ZERO_ADDRESS, tokenA.address, constants.ZERO_ADDRESS, 0],
+          args: [constants.NOT_ZERO_ADDRESS, tokenA.address, constants.ZERO_ADDRESS],
         });
       });
     });
@@ -68,7 +68,7 @@ describe('DCAPairParameters', function () {
       let deploymentTx: TransactionResponse;
       let deployedContract: Contract;
       given(async () => {
-        const deployment = await contracts.deploy(DCAPairParametersContract, [DCAGlobalParameters.address, tokenA.address, tokenB.address, 0]);
+        const deployment = await contracts.deploy(DCAPairParametersContract, [DCAGlobalParameters.address, tokenA.address, tokenB.address]);
         deploymentTx = deployment.tx;
         deployedContract = deployment.contract;
       });

--- a/test/unit/DCAPair/dca-pair-position-handler.spec.ts
+++ b/test/unit/DCAPair/dca-pair-position-handler.spec.ts
@@ -14,7 +14,7 @@ describe('DCAPositionHandler', () => {
   const POSITION_RATE_5 = 5;
   const POSITION_SWAPS_TO_PERFORM_10 = 10;
   const RATE_PER_UNIT_5 = 5;
-  const SWAP_INTERVAL = 0;
+  const SWAP_INTERVAL = 10;
 
   const INITIAL_TOKEN_A_BALANCE_CONTRACT = 100;
   const INITIAL_TOKEN_A_BALANCE_USER = 100;
@@ -66,6 +66,7 @@ describe('DCAPositionHandler', () => {
     await tokenA.mint(approved.address, tokenA.asUnits(INITIAL_TOKEN_A_BALANCE_USER));
     await tokenA.approveInternal(approved.address, DCAPositionHandler.address, tokenA.asUnits(1000));
     await DCAPositionHandler.setPerformedSwaps(SWAP_INTERVAL, PERFORMED_SWAPS_10);
+    await DCAGlobalParameters.addSwapIntervalsToAllowedList([SWAP_INTERVAL], ['NULL']);
   });
 
   describe('constructor', () => {
@@ -95,6 +96,20 @@ describe('DCAPositionHandler', () => {
           rate: POSITION_RATE_5,
           swaps: POSITION_SWAPS_TO_PERFORM_10,
           error: 'DCAPair: invalid deposit address',
+        });
+      });
+    });
+
+    when('making a deposit with non-allowed interval', async () => {
+      given(async () => {
+        await DCAGlobalParameters.removeSwapIntervalsFromAllowedList([SWAP_INTERVAL]);
+      });
+      then('tx is reverted with messasge', async () => {
+        await depositShouldRevert({
+          address: tokenA.address,
+          rate: POSITION_RATE_5,
+          swaps: POSITION_SWAPS_TO_PERFORM_10,
+          error: 'DCAPair: interval not allowed',
         });
       });
     });
@@ -140,6 +155,7 @@ describe('DCAPositionHandler', () => {
             tokenA.address,
             tokenA.asUnits(POSITION_RATE_5),
             PERFORMED_SWAPS_10 + 1,
+            SWAP_INTERVAL,
             PERFORMED_SWAPS_10 + POSITION_SWAPS_TO_PERFORM_10
           );
       });

--- a/test/unit/DCAPair/dca-pair-swap-handler.spec.ts
+++ b/test/unit/DCAPair/dca-pair-swap-handler.spec.ts
@@ -9,7 +9,6 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { readArgFromEvent } from '../../utils/event-utils';
 import { TokenContract } from '../../utils/erc20';
 
-const MINIMUM_SWAP_INTERVAL = BigNumber.from('60');
 const APPLY_FEE = (bn: BigNumber) => bn.mul(3).div(1000);
 
 describe('DCAPairSwapHandler', () => {
@@ -55,9 +54,9 @@ describe('DCAPairSwapHandler', () => {
       tokenA.address,
       tokenB.address,
       DCAGlobalParameters.address, // global parameters
-      staticSlidingOracle.address, // oracle
-      swapInterval
+      staticSlidingOracle.address // oracle
     );
+    await DCAGlobalParameters.addSwapIntervalsToAllowedList([swapInterval], ['NULL']);
   });
 
   describe('constructor', () => {
@@ -65,7 +64,7 @@ describe('DCAPairSwapHandler', () => {
       then('reverts with message', async () => {
         await behaviours.deployShouldRevertWithZeroAddress({
           contract: DCAPairSwapHandlerContract,
-          args: [tokenA.address, tokenB.address, constants.ZERO_ADDRESS, staticSlidingOracle.address, MINIMUM_SWAP_INTERVAL],
+          args: [tokenA.address, tokenB.address, constants.ZERO_ADDRESS, staticSlidingOracle.address],
         });
       });
     });
@@ -73,7 +72,7 @@ describe('DCAPairSwapHandler', () => {
       then('reverts with message', async () => {
         await behaviours.deployShouldRevertWithZeroAddress({
           contract: DCAPairSwapHandlerContract,
-          args: [tokenA.address, tokenB.address, DCAGlobalParameters.address, constants.ZERO_ADDRESS, MINIMUM_SWAP_INTERVAL],
+          args: [tokenA.address, tokenB.address, DCAGlobalParameters.address, constants.ZERO_ADDRESS],
         });
       });
     });
@@ -85,17 +84,12 @@ describe('DCAPairSwapHandler', () => {
           tokenA.address,
           tokenB.address,
           DCAGlobalParameters.address, // global parameters
-          staticSlidingOracle.address,
-          MINIMUM_SWAP_INTERVAL
+          staticSlidingOracle.address
         );
       });
 
       it('oracle is set correctly', async () => {
         expect(await DCAPairSwapHandler.oracle()).to.equal(staticSlidingOracle.address);
-      });
-
-      it('swap interval is set correctly', async () => {
-        expect(await DCAPairSwapHandler.swapInterval()).to.equal(MINIMUM_SWAP_INTERVAL);
       });
     });
   });
@@ -126,7 +120,7 @@ describe('DCAPairSwapHandler', () => {
           previousAccumRatesPerUnitBN,
           previousAccumRatesPerUnitMultiplierBN,
         ]);
-        await DCAPairSwapHandler.addNewRatePerUnit(token(), performedSwapBN, ratePerUnit);
+        await DCAPairSwapHandler.addNewRatePerUnit(swapInterval, token(), performedSwapBN, ratePerUnit);
       });
       then('increments the rates per unit accumulator base and overflow if needed', async () => {
         const accumRatesPerUnit = await DCAPairSwapHandler.accumRatesPerUnit(swapInterval, token(), performedSwapBN);
@@ -231,7 +225,7 @@ describe('DCAPairSwapHandler', () => {
     const ratePerUnitBN = bn.toBN(ratePerUnit);
     when(title, () => {
       given(async () => {
-        await DCAPairSwapHandler.registerSwap(token(), internalAmountUsedToSwapBN, ratePerUnitBN, performedSwapBN);
+        await DCAPairSwapHandler.registerSwap(swapInterval, token(), internalAmountUsedToSwapBN, ratePerUnitBN, performedSwapBN);
       });
       then('sets swap amount accumulator to last internal swap', async () => {
         expect(await DCAPairSwapHandler.swapAmountAccumulator(swapInterval, token())).to.equal(internalAmountUsedToSwapBN);
@@ -280,7 +274,7 @@ describe('DCAPairSwapHandler', () => {
   });
 
   describe('_getAmountToSwap', () => {
-    context('when the amount to swap is augmented (swap amount delta is positive)', () => {
+    when('the amount to swap is augmented (swap amount delta is positive)', () => {
       let swapAmountAccumulator = ethers.constants.MaxUint256.div(2);
       let swapAmountDeltas: BigNumber[] = [];
       const getRandomInt = (min: number, max: number): number => Math.floor(Math.random() * (max - min)) + min;
@@ -297,13 +291,13 @@ describe('DCAPairSwapHandler', () => {
           expect(await DCAPairSwapHandler.swapAmountAccumulator(swapInterval, tokenA.address)).to.equal(swapAmountAccumulator);
           const amountToSwap = swapAmountAccumulator.add(swapAmountDeltas[i - 1]);
           expect(amountToSwap).to.be.gt(swapAmountAccumulator);
-          expect(await DCAPairSwapHandler.getAmountToSwap(tokenA.address, i)).to.equal(amountToSwap);
+          expect(await DCAPairSwapHandler.getAmountToSwap(swapInterval, tokenA.address, i)).to.equal(amountToSwap);
           await DCAPairSwapHandler.setSwapAmountAccumulator(swapInterval, tokenA.address, amountToSwap);
           swapAmountAccumulator = amountToSwap;
         }
       });
     });
-    context('when the amount to swap is reduced (swap amount delta negative)', () => {
+    when('the amount to swap is reduced (swap amount delta negative)', () => {
       context('and swap delta is type(int256).min', () => {
         const swapAmountAccumulator = constants.MAX_INT_256.add(1);
         const swapAmountDelta = constants.MIN_INT_256;
@@ -314,7 +308,7 @@ describe('DCAPairSwapHandler', () => {
         });
         it('calculates correctly the final amount to buy', async () => {
           expect(await DCAPairSwapHandler.swapAmountAccumulator(swapInterval, tokenA.address)).to.equal(swapAmountAccumulator);
-          const amountToSwap = await DCAPairSwapHandler.getAmountToSwap(tokenA.address, swap);
+          const amountToSwap = await DCAPairSwapHandler.getAmountToSwap(swapInterval, tokenA.address, swap);
           expect(amountToSwap).to.be.lt(swapAmountAccumulator);
           expect(amountToSwap).to.equal(swapAmountAccumulator.add(swapAmountDelta));
         });
@@ -334,7 +328,7 @@ describe('DCAPairSwapHandler', () => {
             expect(await DCAPairSwapHandler.swapAmountAccumulator(swapInterval, tokenA.address)).to.equal(swapAmountAccumulator);
             const amountToSwap = swapAmountAccumulator.add(swapAmountDeltas[i - 1]);
             expect(amountToSwap).to.be.lt(swapAmountAccumulator);
-            expect(await DCAPairSwapHandler.getAmountToSwap(tokenA.address, i)).to.equal(amountToSwap);
+            expect(await DCAPairSwapHandler.getAmountToSwap(swapInterval, tokenA.address, i)).to.equal(amountToSwap);
             await DCAPairSwapHandler.setSwapAmountAccumulator(swapInterval, tokenA.address, amountToSwap);
             swapAmountAccumulator = amountToSwap;
           }
@@ -434,7 +428,7 @@ describe('DCAPairSwapHandler', () => {
           ratePerUnitBToA,
         });
         await DCAPairSwapHandler.setInternalBalances((amountToSwapOfTokenA as BigNumber).mul(2), (amountToSwapOfTokenB as BigNumber).mul(2));
-        nextSwapInfo = await DCAPairSwapHandler.getNextSwapInfo();
+        nextSwapInfo = await DCAPairSwapHandler.getNextSwapInfo(swapInterval);
       });
       then('swap to perform is current + 1', () => {
         expect(nextSwapInfo.swapToPerform).to.equal(nextSwapToPerform);
@@ -654,7 +648,7 @@ describe('DCAPairSwapHandler', () => {
         await tokenA.mint(DCAPairSwapHandler.address, initialPairBalanceTokenA);
         await tokenB.mint(DCAPairSwapHandler.address, initialPairBalanceTokenB);
         await DCAPairSwapHandler.setInternalBalances(initialPairBalanceTokenA, initialPairBalanceTokenB);
-        swapTx = DCAPairSwapHandler.connect(swapper)['swap()']({ gasPrice: 0 });
+        swapTx = DCAPairSwapHandler.connect(swapper)['swap(uint32)'](swapInterval, { gasPrice: 0 });
         await behaviours.waitForTxAndNotThrow(swapTx);
       });
 
@@ -883,7 +877,7 @@ describe('DCAPairSwapHandler', () => {
         platformFeeTokenB,
         availableToBorrowTokenA,
         availableToBorrowTokenB,
-      } = await DCAPairSwapHandler.getNextSwapInfo());
+      } = await DCAPairSwapHandler.getNextSwapInfo(swapInterval));
     });
 
     when('doing a reentrancy attack via swap', () => {
@@ -893,8 +887,9 @@ describe('DCAPairSwapHandler', () => {
           'contracts/mocks/DCAPairSwapCallee.sol:ReentrantDCAPairSwapCalleeMock'
         );
         const reentrantDCAPairSwapCallee = await reentrantDCAPairSwapCalleFactory.deploy();
-        await reentrantDCAPairSwapCallee.setAttack((await DCAPairSwapHandler.populateTransaction['swap()']()).data);
-        tx = DCAPairSwapHandler['swap(uint256,uint256,address,bytes)'](
+        await reentrantDCAPairSwapCallee.setAttack((await DCAPairSwapHandler.populateTransaction['swap(uint32)'](swapInterval)).data);
+        tx = DCAPairSwapHandler['swap(uint32,uint256,uint256,address,bytes)'](
+          swapInterval,
           availableToBorrowTokenA,
           availableToBorrowTokenB,
           reentrantDCAPairSwapCallee.address,
@@ -915,7 +910,8 @@ describe('DCAPairSwapHandler', () => {
         const reentrantDCAPairSwapCallee = await reentrantDCAPairSwapCalleFactory.deploy();
         await reentrantDCAPairSwapCallee.setAttack(
           (
-            await DCAPairSwapHandler.populateTransaction['swap(uint256,uint256,address,bytes)'](
+            await DCAPairSwapHandler.populateTransaction['swap(uint32,uint256,uint256,address,bytes)'](
+              swapInterval,
               availableToBorrowTokenA,
               availableToBorrowTokenB,
               reentrantDCAPairSwapCallee.address,
@@ -923,7 +919,8 @@ describe('DCAPairSwapHandler', () => {
             )
           ).data
         );
-        tx = DCAPairSwapHandler['swap(uint256,uint256,address,bytes)'](
+        tx = DCAPairSwapHandler['swap(uint32,uint256,uint256,address,bytes)'](
+          swapInterval,
           availableToBorrowTokenA,
           availableToBorrowTokenB,
           reentrantDCAPairSwapCallee.address,
@@ -938,7 +935,8 @@ describe('DCAPairSwapHandler', () => {
     when('swapper intends to borrow more than available in a', () => {
       let tx: Promise<TransactionResponse>;
       given(async () => {
-        tx = DCAPairSwapHandler['swap(uint256,uint256,address,bytes)'](
+        tx = DCAPairSwapHandler['swap(uint32,uint256,uint256,address,bytes)'](
+          swapInterval,
           availableToBorrowTokenA.add(1),
           availableToBorrowTokenB,
           DCAPairSwapCallee.address,
@@ -953,7 +951,8 @@ describe('DCAPairSwapHandler', () => {
     when('swapper intends to borrow more than available in b', () => {
       let tx: Promise<TransactionResponse>;
       given(async () => {
-        tx = DCAPairSwapHandler['swap(uint256,uint256,address,bytes)'](
+        tx = DCAPairSwapHandler['swap(uint32,uint256,uint256,address,bytes)'](
+          swapInterval,
           availableToBorrowTokenA,
           availableToBorrowTokenB.add(1),
           DCAPairSwapCallee.address,
@@ -969,7 +968,8 @@ describe('DCAPairSwapHandler', () => {
       let tx: TransactionResponse;
 
       given(async () => {
-        tx = await DCAPairSwapHandler['swap(uint256,uint256,address,bytes)'](
+        tx = await DCAPairSwapHandler['swap(uint32,uint256,uint256,address,bytes)'](
+          swapInterval,
           availableToBorrowTokenA,
           availableToBorrowTokenB,
           DCAPairSwapCallee.address,
@@ -1074,7 +1074,8 @@ describe('DCAPairSwapHandler', () => {
 
         given(async () => {
           await DCAPairSwapCallee.returnSpecificAmounts(amountToReturnTokenA(), amountToReturnTokenB());
-          tx = DCAPairSwapHandler['swap(uint256,uint256,address,bytes)'](
+          tx = DCAPairSwapHandler['swap(uint32,uint256,uint256,address,bytes)'](
+            swapInterval,
             amountToBorrowTokenA(),
             amountToBorrowTokenB(),
             DCAPairSwapCallee.address,
@@ -1189,7 +1190,7 @@ describe('DCAPairSwapHandler', () => {
           await tokenB.transfer(DCAPairSwapHandler.address, (amountToBeProvidedBySwapper as BigNumber).add(threshold!));
         }
 
-        swapTx = await DCAPairSwapHandler['swap()']();
+        swapTx = await DCAPairSwapHandler['swap(uint32)'](swapInterval);
       });
       then('token to be provided by swapper needed is provided', async () => {
         if (!tokenToBeProvidedBySwapper) {


### PR DESCRIPTION
Takes out `swapInterval` usage from mocks, as another step to deprecate `swapInterval` as a variable in `DCAPair`