### PR TITLE
[WIP] refactor: deprecate interval argument on swap

### DIFF
--- a/contracts/DCAPair/DCAPairSwapHandler.sol
+++ b/contracts/DCAPair/DCAPairSwapHandler.sol
@@ -2,8 +2,6 @@
 pragma solidity 0.8.4;
 pragma abicoder v2;
 
-import 'hardhat/console.sol';
-
 import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 
 import '../interfaces/ISlidingOracle.sol';
@@ -153,12 +151,11 @@ abstract contract DCAPairSwapHandler is ReentrancyGuard, DCAPairParameters, IDCA
     }
   }
 
-  function swap(uint32 _swapInterval) public override {
-    swap(_swapInterval, 0, 0, msg.sender, '');
+  function swap() public override {
+    swap(0, 0, msg.sender, '');
   }
 
   function swap(
-    uint32 _swapInterval,
     uint256 _amountToBorrowTokenA,
     uint256 _amountToBorrowTokenB,
     address _to,
@@ -167,7 +164,7 @@ abstract contract DCAPairSwapHandler is ReentrancyGuard, DCAPairParameters, IDCA
     IDCAGlobalParameters.SwapParameters memory _swapParameters = globalParameters.swapParameters();
     require(!_swapParameters.isPaused, 'DCAPair: swaps are paused');
     NextSwapInformation memory _nextSwapInformation = _getNextSwapInfo(_swapParameters.swapFee);
-    _swapInterval = _nextSwapInformation.swapsToPerform[0].interval;
+    uint32 _swapInterval = _nextSwapInformation.swapsToPerform[0].interval;
     _registerSwap(
       _swapInterval,
       address(tokenA),

--- a/contracts/interfaces/IDCAPair.sol
+++ b/contracts/interfaces/IDCAPair.sol
@@ -115,10 +115,9 @@ interface IDCAPairSwapHandler {
 
   function getNextSwapInfo() external view returns (NextSwapInformation memory _nextSwapInformation);
 
-  function swap(uint32 _swapInterval) external;
+  function swap() external;
 
   function swap(
-    uint32 _swapInterval,
     uint256 _amountToBorrowTokenA,
     uint256 _amountToBorrowTokenB,
     address _to,

--- a/test/e2e/DCAPair/reentrancy-guard.spec.ts
+++ b/test/e2e/DCAPair/reentrancy-guard.spec.ts
@@ -97,8 +97,8 @@ contract('DCAPair', () => {
       });
 
       testReentrantForFunction({
-        funcAndSignature: 'swap(uint32,uint256,uint256,address,bytes)',
-        args: () => [swapInterval, 0, 0, reentrantDCAPairSwapCallee.address, utils.formatBytes32String('')],
+        funcAndSignature: 'swap(uint256,uint256,address,bytes)',
+        args: () => [0, 0, reentrantDCAPairSwapCallee.address, utils.formatBytes32String('')],
         attackerContract: () => reentrantDCAPairSwapCallee,
       });
     });
@@ -206,7 +206,7 @@ contract('DCAPair', () => {
         funcAndSignature,
         args,
         attackerContract,
-        attack: async () => (await DCAPair.populateTransaction['swap(uint32)'](0)).data!,
+        attack: async () => (await DCAPair.populateTransaction['swap()']()).data!,
       });
 
       testReentrantAttack({
@@ -215,7 +215,7 @@ contract('DCAPair', () => {
         args,
         attackerContract,
         attack: async () =>
-          (await DCAPair.populateTransaction['swap(uint32,uint256,uint256,address,bytes)'](0, 0, 0, constants.NOT_ZERO_ADDRESS, '0x')).data!,
+          (await DCAPair.populateTransaction['swap(uint256,uint256,address,bytes)'](0, 0, constants.NOT_ZERO_ADDRESS, '0x')).data!,
       });
 
       testReentrantAttack({

--- a/test/unit/DCAPair/dca-pair-swap-handler.spec.ts
+++ b/test/unit/DCAPair/dca-pair-swap-handler.spec.ts
@@ -784,7 +784,7 @@ describe('DCAPairSwapHandler', () => {
         await tokenA.mint(DCAPairSwapHandler.address, initialPairBalanceTokenA);
         await tokenB.mint(DCAPairSwapHandler.address, initialPairBalanceTokenB);
         await DCAPairSwapHandler.setInternalBalances(initialPairBalanceTokenA, initialPairBalanceTokenB);
-        swapTx = DCAPairSwapHandler.connect(swapper)['swap(uint32)'](SWAP_INTERVAL, { gasPrice: 0 });
+        swapTx = DCAPairSwapHandler.connect(swapper)['swap()']({ gasPrice: 0 });
         await behaviours.waitForTxAndNotThrow(swapTx);
       });
 
@@ -1010,9 +1010,8 @@ describe('DCAPairSwapHandler', () => {
           'contracts/mocks/DCAPairSwapCallee.sol:ReentrantDCAPairSwapCalleeMock'
         );
         const reentrantDCAPairSwapCallee = await reentrantDCAPairSwapCalleFactory.deploy();
-        await reentrantDCAPairSwapCallee.setAttack((await DCAPairSwapHandler.populateTransaction['swap(uint32)'](SWAP_INTERVAL)).data);
-        tx = DCAPairSwapHandler['swap(uint32,uint256,uint256,address,bytes)'](
-          SWAP_INTERVAL,
+        await reentrantDCAPairSwapCallee.setAttack((await DCAPairSwapHandler.populateTransaction['swap()']()).data);
+        tx = DCAPairSwapHandler['swap(uint256,uint256,address,bytes)'](
           availableToBorrowTokenA,
           availableToBorrowTokenB,
           reentrantDCAPairSwapCallee.address,
@@ -1033,8 +1032,7 @@ describe('DCAPairSwapHandler', () => {
         const reentrantDCAPairSwapCallee = await reentrantDCAPairSwapCalleFactory.deploy();
         await reentrantDCAPairSwapCallee.setAttack(
           (
-            await DCAPairSwapHandler.populateTransaction['swap(uint32,uint256,uint256,address,bytes)'](
-              SWAP_INTERVAL,
+            await DCAPairSwapHandler.populateTransaction['swap(uint256,uint256,address,bytes)'](
               availableToBorrowTokenA,
               availableToBorrowTokenB,
               reentrantDCAPairSwapCallee.address,
@@ -1042,8 +1040,7 @@ describe('DCAPairSwapHandler', () => {
             )
           ).data
         );
-        tx = DCAPairSwapHandler['swap(uint32,uint256,uint256,address,bytes)'](
-          SWAP_INTERVAL,
+        tx = DCAPairSwapHandler['swap(uint256,uint256,address,bytes)'](
           availableToBorrowTokenA,
           availableToBorrowTokenB,
           reentrantDCAPairSwapCallee.address,
@@ -1058,8 +1055,7 @@ describe('DCAPairSwapHandler', () => {
     when('swapper intends to borrow more than available in a', () => {
       let tx: Promise<TransactionResponse>;
       given(async () => {
-        tx = DCAPairSwapHandler['swap(uint32,uint256,uint256,address,bytes)'](
-          SWAP_INTERVAL,
+        tx = DCAPairSwapHandler['swap(uint256,uint256,address,bytes)'](
           availableToBorrowTokenA.add(1),
           availableToBorrowTokenB,
           DCAPairSwapCallee.address,
@@ -1074,8 +1070,7 @@ describe('DCAPairSwapHandler', () => {
     when('swapper intends to borrow more than available in b', () => {
       let tx: Promise<TransactionResponse>;
       given(async () => {
-        tx = DCAPairSwapHandler['swap(uint32,uint256,uint256,address,bytes)'](
-          SWAP_INTERVAL,
+        tx = DCAPairSwapHandler['swap(uint256,uint256,address,bytes)'](
           availableToBorrowTokenA,
           availableToBorrowTokenB.add(1),
           DCAPairSwapCallee.address,
@@ -1091,8 +1086,7 @@ describe('DCAPairSwapHandler', () => {
       let tx: TransactionResponse;
 
       given(async () => {
-        tx = await DCAPairSwapHandler['swap(uint32,uint256,uint256,address,bytes)'](
-          SWAP_INTERVAL,
+        tx = await DCAPairSwapHandler['swap(uint256,uint256,address,bytes)'](
           availableToBorrowTokenA,
           availableToBorrowTokenB,
           DCAPairSwapCallee.address,
@@ -1197,8 +1191,7 @@ describe('DCAPairSwapHandler', () => {
 
         given(async () => {
           await DCAPairSwapCallee.returnSpecificAmounts(amountToReturnTokenA(), amountToReturnTokenB());
-          tx = DCAPairSwapHandler['swap(uint32,uint256,uint256,address,bytes)'](
-            SWAP_INTERVAL,
+          tx = DCAPairSwapHandler['swap(uint256,uint256,address,bytes)'](
             amountToBorrowTokenA(),
             amountToBorrowTokenB(),
             DCAPairSwapCallee.address,
@@ -1313,7 +1306,7 @@ describe('DCAPairSwapHandler', () => {
           await tokenB.transfer(DCAPairSwapHandler.address, (amountToBeProvidedBySwapper as BigNumber).add(threshold!));
         }
 
-        swapTx = await DCAPairSwapHandler['swap(uint32)'](SWAP_INTERVAL);
+        swapTx = await DCAPairSwapHandler['swap()']();
       });
       then('token to be provided by swapper needed is provided', async () => {
         if (!tokenToBeProvidedBySwapper) {


### PR DESCRIPTION
We deprecate the `interval` argument on swap and flash-swap, since its no longer necessary.