### PR TITLE
refactor: remove double accum

### DIFF
--- a/contracts/DCAPair/DCAPairParameters.sol
+++ b/contracts/DCAPair/DCAPairParameters.sol
@@ -23,7 +23,7 @@ abstract contract DCAPairParameters is IDCAPairParameters {
   // Tracking
   mapping(uint32 => mapping(address => mapping(uint32 => int256))) public override swapAmountDelta; // swap interval => from token => swap number => delta
   mapping(uint32 => uint32) public override performedSwaps; // swap interval => performed swaps
-  mapping(uint32 => mapping(address => mapping(uint32 => uint256[2]))) internal _accumRatesPerUnit; // swap interval => from token => swap number => accum
+  mapping(uint32 => mapping(address => mapping(uint32 => uint256))) internal _accumRatesPerUnit; // swap interval => from token => swap number => accum
   mapping(address => uint256) internal _balances;
 
   constructor(

--- a/contracts/DCAPair/DCAPairSwapHandler.sol
+++ b/contracts/DCAPair/DCAPairSwapHandler.sol
@@ -29,18 +29,8 @@ abstract contract DCAPairSwapHandler is ReentrancyGuard, DCAPairParameters, IDCA
     uint32 _performedSwap,
     uint256 _ratePerUnit
   ) internal {
-    uint32 _previousSwap = _performedSwap - 1;
-    uint256[2] memory _accumRatesPerUnitPreviousSwap = _accumRatesPerUnit[_swapInterval][_address][_previousSwap];
-    (bool _ok, uint256 _result) = Math.tryAdd(_accumRatesPerUnitPreviousSwap[0], _ratePerUnit);
-    if (_ok) {
-      _accumRatesPerUnit[_swapInterval][_address][_performedSwap] = [_result, _accumRatesPerUnitPreviousSwap[1]];
-    } else {
-      uint256 _missingUntilOverflow = type(uint256).max - _accumRatesPerUnitPreviousSwap[0];
-      _accumRatesPerUnit[_swapInterval][_address][_performedSwap] = [
-        _ratePerUnit - _missingUntilOverflow,
-        _accumRatesPerUnitPreviousSwap[1] + 1
-      ];
-    }
+    uint256 _accumRatesPerUnitPreviousSwap = _accumRatesPerUnit[_swapInterval][_address][_performedSwap - 1];
+    _accumRatesPerUnit[_swapInterval][_address][_performedSwap] = _accumRatesPerUnitPreviousSwap + _ratePerUnit;
   }
 
   function _registerSwap(

--- a/contracts/DCAPair/utils/Math.sol
+++ b/contracts/DCAPair/utils/Math.sol
@@ -13,17 +13,4 @@ library Math {
       return (true, c);
     }
   }
-
-  /**
-   * @dev Returns the addition of two unsigned integers, with an overflow flag.
-   *
-   * _Available since v3.4._
-   */
-  function tryAdd(uint256 a, uint256 b) internal pure returns (bool, uint256) {
-    unchecked {
-      uint256 c = a + b;
-      if (c < a) return (false, 0);
-      return (true, c);
-    }
-  }
 }

--- a/contracts/mocks/DCAFactory/DCAFactoryPairsHandler.sol
+++ b/contracts/mocks/DCAFactory/DCAFactoryPairsHandler.sol
@@ -7,7 +7,7 @@ import '../../DCAFactory/DCAFactoryPairsHandler.sol';
 contract DCAFactoryPairsHandlerMock is DCAFactoryPairsHandler {
   constructor(IDCAGlobalParameters _globalParameters) DCAFactoryPairsHandler(_globalParameters) {}
 
-  // function sortTokens(address _tokenA, address _tokenB) public pure returns (address _token0, address _token1) {
-  //   (_token0, _token1) = _sortTokens(_tokenA, _tokenB);
-  // }
+  function sortTokens(address _tokenA, address _tokenB) public pure returns (address _token0, address _token1) {
+    (_token0, _token1) = _sortTokens(_tokenA, _tokenB);
+  }
 }

--- a/contracts/mocks/DCAPair/DCAPairParameters.sol
+++ b/contracts/mocks/DCAPair/DCAPairParameters.sol
@@ -43,7 +43,7 @@ contract DCAPairParametersMock is DCAPairParameters {
     uint32 _swapInterval,
     address _tokenAddress,
     uint32 _swap,
-    uint256[2] memory _accumRatePerUnit
+    uint256 _accumRatePerUnit
   ) public {
     _accumRatesPerUnit[_swapInterval][_tokenAddress][_swap] = _accumRatePerUnit;
   }
@@ -52,7 +52,7 @@ contract DCAPairParametersMock is DCAPairParameters {
     uint32 _swapInterval,
     address _tokenAddress,
     uint32 _swap
-  ) public view returns (uint256[2] memory) {
+  ) public view returns (uint256) {
     return _accumRatesPerUnit[_swapInterval][_tokenAddress][_swap];
   }
 
@@ -64,10 +64,9 @@ contract DCAPairParametersMock is DCAPairParameters {
     uint32 _swapInterval,
     address _tokenAddress,
     uint32 _swap,
-    uint256 _rate,
-    uint256 _rateMultiplier
+    uint256 _rate
   ) public {
-    _accumRatesPerUnit[_swapInterval][_tokenAddress][_swap] = [_rate, _rateMultiplier];
+    _accumRatesPerUnit[_swapInterval][_tokenAddress][_swap] = _rate;
   }
 
   function getFeeFromAmount(uint32 _feeAmount, uint256 _amount) public view returns (uint256) {

--- a/test/unit/DCAFactory/dca-factory-pairs-handler.spec.ts
+++ b/test/unit/DCAFactory/dca-factory-pairs-handler.spec.ts
@@ -156,7 +156,7 @@ describe('DCAFactoryPairsHandler', function () {
     });
   });
 
-  describe.skip('sortTokens', () => {
+  describe('sortTokens', () => {
     when('sorting token addresses', () => {
       let token0: string;
       let token1: string;


### PR DESCRIPTION
## The change
We are now removing the double accum we were using, since it definitely was an overkill. 

Bytecode size went from 20.46Kb to 19.81Kb.

And swap gas went from 227941 to 218037.

## The reason behind it
We want to know if uint256 will be enough to store all accumulated rates. Now, let's remember that the accumulated rates will store the accumulation of how much of token _TO_ I can get with 1 of token _FROM_. So let's see how big the difference between tokenA and tokenB has to be to fill an `uint256` in 10 years.

```
amount of swaps = max(uint256) / worst posible rate
amount of swaps in 10 years (with hourly swaps) = 24 * 365 * 10

worst posible rate * 24 * 365 * 10 > max(uint256) <=>
worst posible rate > max(uint256) / (24 * 365 * 10) = max(uint 256) / 87600 <=>
worst posible rate > 1.32 * 10**72
```

So there aren't any tokens remotely close to this difference, so we should be ok with a `uint256`