### PR TITLE
test: checks overflow and underflow errors

### DIFF
--- a/test/unit/DCAPair/dca-pair-position-handler.spec.ts
+++ b/test/unit/DCAPair/dca-pair-position-handler.spec.ts
@@ -958,9 +958,8 @@ describe('DCAPositionHandler', () => {
 
       return behaviours.checkTxRevertedWithMessage({
         tx,
-        message: new RegExp("\\b(overflow|Transaction reverted and Hardhat couldn't infer the reason)\\b"),
+        message: 'reverted with panic code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)',
       });
-      // TODO: Remove hack above when Hardhat detects native overflows correctly
     }
   });
 

--- a/test/unit/DCAPair/dca-pair-swap-handler.spec.ts
+++ b/test/unit/DCAPair/dca-pair-swap-handler.spec.ts
@@ -678,7 +678,7 @@ describe('DCAPairSwapHandler', () => {
       amountToSwapOfTokenA: 2,
       amountToSwapOfTokenB: 1,
       ratePerUnitBToA: 1,
-      reason: `Transaction reverted and Hardhat couldn't infer the reason.`, // TODO: change when Hardhat detects underflows correctly
+      reason: `reverted with panic code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)`,
     });
 
     swapTestFailed({


### PR DESCRIPTION
With the new version of `hardhat`, now we can (and should) test for `undeflows` and `overflows` correctly.