### PR TITLE
perf: stop assigning zero to zeroed vars

### DIFF
--- a/contracts/DCAGlobalParameters/DCAGlobalParameters.sol
+++ b/contracts/DCAGlobalParameters/DCAGlobalParameters.sol
@@ -53,7 +53,7 @@ contract DCAGlobalParameters is IDCAGlobalParameters, Governable, Pausable {
 
   function addSwapIntervalsToAllowedList(uint32[] calldata _swapIntervals, string[] calldata _descriptions) public override onlyGovernor {
     require(_swapIntervals.length == _descriptions.length, 'DCAGParameters: invalid params');
-    for (uint256 i = 0; i < _swapIntervals.length; i++) {
+    for (uint256 i; i < _swapIntervals.length; i++) {
       require(_swapIntervals[i] > 0, 'DCAGParameters: zero interval');
       require(bytes(_descriptions[i]).length > 0, 'DCAGParameters: empty text');
       require(!isSwapIntervalAllowed(_swapIntervals[i]), 'DCAGParameters: already allowed');
@@ -64,7 +64,7 @@ contract DCAGlobalParameters is IDCAGlobalParameters, Governable, Pausable {
   }
 
   function removeSwapIntervalsFromAllowedList(uint32[] calldata _swapIntervals) public override onlyGovernor {
-    for (uint256 i = 0; i < _swapIntervals.length; i++) {
+    for (uint256 i; i < _swapIntervals.length; i++) {
       require(isSwapIntervalAllowed(_swapIntervals[i]), 'DCAGParameters: invalid interval');
       _allowedSwapIntervals.remove(_swapIntervals[i]);
       delete intervalDescription[_swapIntervals[i]];
@@ -75,7 +75,7 @@ contract DCAGlobalParameters is IDCAGlobalParameters, Governable, Pausable {
   function allowedSwapIntervals() external view override returns (uint32[] memory __allowedSwapIntervals) {
     uint256 _allowedSwapIntervalsLength = _allowedSwapIntervals.length();
     __allowedSwapIntervals = new uint32[](_allowedSwapIntervalsLength);
-    for (uint256 i = 0; i < _allowedSwapIntervalsLength; i++) {
+    for (uint256 i; i < _allowedSwapIntervalsLength; i++) {
       __allowedSwapIntervals[i] = uint32(_allowedSwapIntervals.at(i));
     }
   }

--- a/contracts/DCAPair/DCAPairPositionHandler.sol
+++ b/contracts/DCAPair/DCAPairPositionHandler.sol
@@ -10,7 +10,7 @@ abstract contract DCAPairPositionHandler is ReentrancyGuard, DCAPairParameters, 
   using SafeERC20 for IERC20Detailed;
 
   mapping(uint256 => DCA) internal _userPositions;
-  uint256 internal _idCounter = 0;
+  uint256 internal _idCounter;
 
   constructor(IERC20Detailed _tokenA, IERC20Detailed _tokenB)
     ERC721(string(abi.encodePacked('DCA: ', _tokenA.symbol(), ' - ', _tokenB.symbol())), 'DCA')
@@ -82,7 +82,7 @@ abstract contract DCAPairPositionHandler is ReentrancyGuard, DCAPairParameters, 
     nonReentrant
     returns (uint256 _swappedTokenA, uint256 _swappedTokenB)
   {
-    for (uint256 i = 0; i < _dcaIds.length; i++) {
+    for (uint256 i; i < _dcaIds.length; i++) {
       uint256 _dcaId = _dcaIds[i];
       _assertPositionExistsAndCanBeOperatedByCaller(_dcaId);
       uint256 _swappedDCA = _calculateSwapped(_dcaId);


### PR DESCRIPTION
I had a vision (?). When we assign zero to variables that initialize already with a zero value, we are just wasting gas.

[Diff checker](https://www.diffchecker.com/wYzTxHfE)