### PR TITLE
feat: add subsidy pool

### DIFF
--- a/contracts/DCASubsidyPool/MultiAsymmetricPool/MAPParameters.sol
+++ b/contracts/DCASubsidyPool/MultiAsymmetricPool/MAPParameters.sol
@@ -1,0 +1,38 @@
+//SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.4;
+
+import 'hardhat/console.sol';
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import '../../interfaces/IERC20Detailed.sol';
+
+interface IMAParameters {
+  struct Liquidity {
+    uint256 tokenA;
+    uint256 tokenB;
+  }
+
+  struct PairData {
+    address tokenA;
+    address tokenB;
+  }
+
+  function liquidity(address _pair) external view returns (uint256 _tokenA, uint256 _tokenB);
+}
+
+abstract contract MAPParameters is IMAParameters {
+  // Tracking
+  mapping(address => Liquidity) public override liquidity;
+  mapping(address => PairData) internal _pairs;
+
+  function _getPairData(address _pair) internal view returns (PairData memory _pairData) {
+    PairData memory _cachedData = _pairs[_pair];
+
+    if (_cachedData.tokenA == address(0)) {
+      // TODO: If not cached, then fetch info and cache it
+
+      revert('MAP: Seems like the given pair does not exist');
+    }
+
+    _pairData = _pairs[_pair];
+  }
+}

--- a/contracts/DCASubsidyPool/MultiAsymmetricPool/MAPPositionHandler.sol
+++ b/contracts/DCASubsidyPool/MultiAsymmetricPool/MAPPositionHandler.sol
@@ -1,0 +1,111 @@
+//SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.4;
+
+import './MAPParameters.sol';
+
+interface IMAPPositionHandler {
+  struct PoolPosition {
+    address pair;
+    uint256 shares;
+    uint104 ratioB; // Determines how much of the liquidity added was in token B
+  }
+
+  event Deposited(address indexed _user, address _pair, uint256 _amountTokenA, uint256 _amountTokenB, uint256 _positionId, uint256 _shares);
+
+  // solhint-disable-next-line func-name-mixedcase
+  function POSITION_RATIO_PRECISION() external view returns (uint104);
+
+  function deposit(
+    address _pair,
+    uint256 _amountTokenA,
+    uint256 _amountTokenB
+  ) external returns (uint256 _positionId);
+
+  function calculateOwned(uint256 _positionId) external view returns (uint256 _amountTokenA, uint256 _amountTokenB);
+
+  function totalShares(address _pair) external view returns (uint256 _totalShares);
+
+  function positions(uint256 _positionId)
+    external
+    view
+    returns (
+      address _pair,
+      uint256 _shares,
+      uint104 _ratioFromAToBB
+    );
+}
+
+abstract contract MAPPositionHandler is IMAPPositionHandler, MAPParameters {
+  using SafeERC20 for IERC20Detailed;
+
+  // solhint-disable-next-line var-name-mixedcase
+  uint104 public override POSITION_RATIO_PRECISION = 10**30;
+
+  mapping(address => uint256) public override totalShares;
+  mapping(uint256 => PoolPosition) public override positions;
+
+  uint256 private _counter;
+
+  // TODO: remove and actually call oracle
+  uint256 internal _oracleRatioFromAToB;
+
+  function _deposit(
+    address _pair,
+    uint256 _amountTokenA,
+    uint256 _amountTokenB
+  ) internal returns (uint256 _positionId) {
+    PairData memory _pairData = _getPairData(_pair);
+
+    IERC20Detailed(_pairData.tokenA).safeTransferFrom(msg.sender, address(this), _amountTokenA);
+    IERC20Detailed(_pairData.tokenB).safeTransferFrom(msg.sender, address(this), _amountTokenB);
+
+    uint256 _ratioFromAToB = _fetchRatio();
+    uint256 _liquidity = _amountTokenA * _ratioFromAToB + _amountTokenB;
+    require(_liquidity > 0, 'MAP: Deposited liquidity must be positive');
+
+    uint256 _totalLiquidity = liquidity[_pair].tokenA * _ratioFromAToB + liquidity[_pair].tokenB;
+    uint256 _shares = totalShares[_pair] == 0 ? _liquidity : (_liquidity * totalShares[_pair]) / _totalLiquidity;
+    uint104 _ratioB = uint104((_amountTokenB * POSITION_RATIO_PRECISION) / _liquidity); // TODO: Check for overflow or reduced to zero
+
+    // Create position
+    _positionId = ++_counter;
+    positions[_positionId] = PoolPosition({pair: _pair, ratioB: _ratioB, shares: _shares});
+
+    // Update liquidity
+    liquidity[_pair].tokenA += _amountTokenA;
+    liquidity[_pair].tokenB += _amountTokenB;
+
+    // Update shares
+    totalShares[_pair] += _shares;
+
+    emit Deposited(msg.sender, _pair, _amountTokenA, _amountTokenB, _positionId, _shares);
+  }
+
+  function _calculateOwned(uint256 _positionId) internal view returns (uint256 _amountTokenA, uint256 _amountTokenB) {
+    PoolPosition memory _position = positions[_positionId];
+
+    require(_position.shares > 0, 'MAP: Invalid position id');
+
+    uint256 _ratioFromAToB = _fetchRatio();
+    uint256 _totalLiquidity = liquidity[_position.pair].tokenA * _ratioFromAToB + liquidity[_position.pair].tokenB; // TODO: evaluate how to choose if base token should be A or B. Now it's always B
+    uint256 _ownedLiquidity = (_totalLiquidity * _position.shares) / totalShares[_position.pair];
+
+    _amountTokenA = (_ownedLiquidity * (POSITION_RATIO_PRECISION - _position.ratioB)) / POSITION_RATIO_PRECISION / _ratioFromAToB; // TODO: this workes only when decimals(tokenA) = decimals(tokenB). When we integrate with oracle, we will need to change this
+    _amountTokenB = (_ownedLiquidity * _position.ratioB) / POSITION_RATIO_PRECISION;
+
+    if (_amountTokenA > liquidity[_position.pair].tokenA) {
+      uint256 _diff = _amountTokenA - liquidity[_position.pair].tokenA;
+      _amountTokenA = liquidity[_position.pair].tokenA;
+      _amountTokenB += _diff * _ratioFromAToB;
+    } else if (_amountTokenB > liquidity[_position.pair].tokenB) {
+      uint256 _diff = _amountTokenB - liquidity[_position.pair].tokenB;
+      _amountTokenA += _diff / _ratioFromAToB;
+      _amountTokenB = liquidity[_position.pair].tokenB;
+    }
+  }
+
+  /** Returns the ratio from tokenA to tokenB */
+  function _fetchRatio() private view returns (uint256 _ratioFromAToB) {
+    _ratioFromAToB = _oracleRatioFromAToB;
+  }
+}

--- a/contracts/mocks/DCASubsidyPool/MultiAsymmetricPool/MAPParameters.sol
+++ b/contracts/mocks/DCASubsidyPool/MultiAsymmetricPool/MAPParameters.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.4;
+
+import '../../../DCASubsidyPool/MultiAsymmetricPool/MAPParameters.sol';
+
+contract MAPParametersMock is MAPParameters {
+  // Mocks setters
+  function setPairData(
+    address _pair,
+    address _tokenA,
+    address _tokenB
+  ) public {
+    _pairs[_pair] = PairData(_tokenA, _tokenB);
+  }
+
+  function addLiquidity(
+    address _pair,
+    uint256 _amountTokenA,
+    uint256 _amountTokenB
+  ) public {
+    liquidity[_pair].tokenA += _amountTokenA;
+    liquidity[_pair].tokenB += _amountTokenB;
+  }
+
+  function setLiquidity(
+    address _pair,
+    uint256 _amountTokenA,
+    uint256 _amountTokenB
+  ) public {
+    liquidity[_pair].tokenA = _amountTokenA;
+    liquidity[_pair].tokenB = _amountTokenB;
+  }
+}

--- a/contracts/mocks/DCASubsidyPool/MultiAsymmetricPool/MAPPositionHandler.sol
+++ b/contracts/mocks/DCASubsidyPool/MultiAsymmetricPool/MAPPositionHandler.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.4;
+
+import '../../../DCASubsidyPool/MultiAsymmetricPool/MAPPositionHandler.sol';
+import './MAPParameters.sol';
+
+contract MAPPositionHandlerMock is MAPPositionHandler, MAPParametersMock {
+  function deposit(
+    address _pair,
+    uint256 _amountTokenA,
+    uint256 _amountTokenB
+  ) public override returns (uint256 _positionId) {
+    _positionId = _deposit(_pair, _amountTokenA, _amountTokenB);
+  }
+
+  function calculateOwned(uint256 _positionId) public view override returns (uint256 _amountTokenA, uint256 _amountTokenB) {
+    (_amountTokenA, _amountTokenB) = _calculateOwned(_positionId);
+  }
+
+  function setRatio(uint256 _ratio) public {
+    _oracleRatioFromAToB = _ratio;
+  }
+
+  function setTotalShares(address _pair, uint256 _totalShares) public {
+    totalShares[_pair] = _totalShares;
+  }
+}

--- a/test/unit/DCASubsidyPool/MultiAsymmetricPool/map-position-handler.spec.ts
+++ b/test/unit/DCASubsidyPool/MultiAsymmetricPool/map-position-handler.spec.ts
@@ -1,0 +1,228 @@
+import { BigNumber, Contract, ContractFactory } from 'ethers';
+import { ethers } from 'hardhat';
+import { erc20, behaviours, constants } from '../../../utils';
+import { expect } from 'chai';
+import { TransactionResponse } from '@ethersproject/abstract-provider';
+import { readArgFromEventOrFail } from '../../../utils/event-utils';
+import { when, then, given } from '../../../utils/bdd';
+import { TokenContract } from '../../../utils/erc20';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signers';
+
+describe('MAPPositionHandler', () => {
+  const INITIAL_TOKEN_A_BALANCE_USER = 1;
+  const INITIAL_TOKEN_B_BALANCE_USER = 100;
+  const PAIR_ADDRESS = '0x0000000000000000000000000000000000000002';
+  const INITIAL_PAIR_LIQUIDITY_A = 100;
+  const INITIAL_PAIR_LIQUIDITY_B = 100;
+  const INITIAL_SHARES_VALUE = 2;
+  const TOKEN_RATIO = 100; // 1 tokenA = ${TOKEN_RATE} tokenB
+
+  let owner: SignerWithAddress;
+  let tokenA: TokenContract, tokenB: TokenContract;
+  let MAPPositionHandlerContract: ContractFactory;
+  let MAPPositionHandler: Contract;
+  let positionRatioPrecision: BigNumber;
+  let initialAmountOfShares: BigNumber;
+
+  before('Setup accounts and contracts', async () => {
+    [owner] = await ethers.getSigners();
+    MAPPositionHandlerContract = await ethers.getContractFactory(
+      'contracts/mocks/DCASubsidyPool/MultiAsymmetricPool/MAPPositionHandler.sol:MAPPositionHandlerMock'
+    );
+  });
+
+  beforeEach('Deploy and configure', async () => {
+    tokenA = await erc20.deploy({
+      name: 'DAI',
+      symbol: 'DAI',
+      decimals: 18,
+    });
+    tokenB = await erc20.deploy({
+      name: 'WBTC',
+      symbol: 'WBTC',
+      decimals: 18,
+    });
+    MAPPositionHandler = await MAPPositionHandlerContract.deploy();
+    await tokenA.approveInternal(owner.address, MAPPositionHandler.address, constants.MAX_UINT_256);
+    await tokenB.approveInternal(owner.address, MAPPositionHandler.address, constants.MAX_UINT_256);
+    await tokenA.mint(owner.address, tokenA.asUnits(INITIAL_TOKEN_A_BALANCE_USER));
+    await tokenB.mint(owner.address, tokenB.asUnits(INITIAL_TOKEN_B_BALANCE_USER));
+
+    positionRatioPrecision = await MAPPositionHandler.POSITION_RATIO_PRECISION();
+    await MAPPositionHandler.setPairData(PAIR_ADDRESS, tokenA.address, tokenB.address);
+    await MAPPositionHandler.setRatio(TOKEN_RATIO);
+    await MAPPositionHandler.setLiquidity(PAIR_ADDRESS, tokenA.asUnits(INITIAL_PAIR_LIQUIDITY_A), tokenB.asUnits(INITIAL_PAIR_LIQUIDITY_B));
+
+    const initialLiquidity = tokenA.asUnits(INITIAL_PAIR_LIQUIDITY_A).mul(TOKEN_RATIO).add(tokenB.asUnits(INITIAL_PAIR_LIQUIDITY_B));
+    initialAmountOfShares = initialLiquidity.div(INITIAL_SHARES_VALUE);
+    await MAPPositionHandler.setTotalShares(PAIR_ADDRESS, initialAmountOfShares);
+  });
+
+  describe('deposit', () => {
+    const depositShouldRevert = ({
+      pair,
+      tokenA: amountTokenA,
+      tokenB: amountTokenB,
+      error,
+    }: {
+      pair: string;
+      tokenA: number;
+      tokenB: number;
+      error: string;
+    }) =>
+      behaviours.txShouldRevertWithMessage({
+        contract: MAPPositionHandler,
+        func: 'deposit',
+        args: [pair, tokenA.asUnits(amountTokenA), tokenB.asUnits(amountTokenB)],
+        message: error,
+      });
+
+    when('making a deposit with an unknown pair', () => {
+      then('tx is reverted with message', async () => {
+        await depositShouldRevert({
+          pair: constants.NOT_ZERO_ADDRESS,
+          tokenA: INITIAL_TOKEN_A_BALANCE_USER,
+          tokenB: INITIAL_TOKEN_B_BALANCE_USER,
+          error: 'MAP: Seems like the given pair does not exist',
+        });
+      });
+    });
+
+    when('making a deposit with no value', () => {
+      then('tx is reverted with message', async () => {
+        await depositShouldRevert({
+          pair: PAIR_ADDRESS,
+          tokenA: 0,
+          tokenB: 0,
+          error: 'MAP: Deposited liquidity must be positive',
+        });
+      });
+    });
+
+    when('making a valid deposit', async () => {
+      let positionId: BigNumber;
+      let tx: TransactionResponse;
+      let depositedTokenA: BigNumber;
+      let depositedTokenB: BigNumber;
+      let depositedLiquidity: BigNumber;
+      let shares: BigNumber;
+
+      given(async () => {
+        ({ tx, positionId } = await deposit(PAIR_ADDRESS, INITIAL_TOKEN_A_BALANCE_USER, INITIAL_TOKEN_B_BALANCE_USER));
+
+        depositedTokenA = tokenA.asUnits(INITIAL_TOKEN_A_BALANCE_USER);
+        depositedTokenB = tokenB.asUnits(INITIAL_TOKEN_B_BALANCE_USER);
+        depositedLiquidity = getLiquidityWithRatio({
+          amountTokenA: INITIAL_TOKEN_A_BALANCE_USER,
+          amountTokenB: INITIAL_TOKEN_B_BALANCE_USER,
+          ratio: TOKEN_RATIO,
+        });
+        const existingLiquidity = getLiquidityWithRatio({
+          amountTokenA: INITIAL_PAIR_LIQUIDITY_A,
+          amountTokenB: INITIAL_PAIR_LIQUIDITY_B,
+          ratio: TOKEN_RATIO,
+        });
+
+        shares = depositedLiquidity.mul(initialAmountOfShares).div(existingLiquidity);
+      });
+
+      then('event is emitted correctly', async () => {
+        await expect(tx)
+          .to.emit(MAPPositionHandler, 'Deposited')
+          .withArgs(owner.address, PAIR_ADDRESS, depositedTokenA, depositedTokenB, 1, shares);
+      });
+
+      then('total shares are increased for pair', async () => {
+        const totalShares = await MAPPositionHandler.totalShares(PAIR_ADDRESS);
+        expect(totalShares).to.equal(shares.add(initialAmountOfShares));
+      });
+
+      then('liquidity is increased for pair', async () => {
+        const [amountTokenA, amountTokenB] = await MAPPositionHandler.liquidity(PAIR_ADDRESS);
+        expect(amountTokenA).to.equal(depositedTokenA.add(tokenA.asUnits(INITIAL_PAIR_LIQUIDITY_A)));
+        expect(amountTokenB).to.equal(depositedTokenB.add(tokenB.asUnits(INITIAL_PAIR_LIQUIDITY_B)));
+      });
+
+      then('correct amount is transferred from sender', async () => {
+        await expectBalanceToBe(tokenA, owner.address, 0);
+        await expectBalanceToBe(tokenB, owner.address, 0);
+        await expectBalanceToBe(tokenA, MAPPositionHandler.address, INITIAL_TOKEN_A_BALANCE_USER);
+
+        await expectBalanceToBe(tokenB, MAPPositionHandler.address, INITIAL_TOKEN_B_BALANCE_USER);
+      });
+
+      then('position is created', async () => {
+        await expectPositionToBe(positionId, {
+          shares: shares,
+          ratioTokenB: depositedTokenB.mul(positionRatioPrecision).div(depositedLiquidity),
+        });
+      });
+    });
+  });
+
+  describe('calculateOwned', () => {
+    when(`when position doesn't exist`, async () => {
+      then('tx is reverted with message', async () => {
+        behaviours.txShouldRevertWithMessage({
+          contract: MAPPositionHandler,
+          func: 'calculateOwned',
+          args: [1],
+          message: 'MAP: Invalid position id',
+        });
+      });
+    });
+
+    when(`ratio doesn't change and no swaps were executed`, async () => {
+      let positionId: BigNumber;
+      let depositedTokenA: BigNumber;
+      let depositedTokenB: BigNumber;
+
+      given(async () => {
+        ({ positionId } = await deposit(PAIR_ADDRESS, INITIAL_TOKEN_A_BALANCE_USER, INITIAL_TOKEN_B_BALANCE_USER));
+
+        depositedTokenA = tokenA.asUnits(INITIAL_TOKEN_A_BALANCE_USER);
+        depositedTokenB = tokenB.asUnits(INITIAL_TOKEN_B_BALANCE_USER);
+      });
+
+      then('owned is exactly as deposited', async () => {
+        const [ownedTokenA, ownedTokenB] = await MAPPositionHandler.calculateOwned(positionId);
+        expect(ownedTokenA).to.equal(depositedTokenA);
+        expect(ownedTokenB).to.equal(depositedTokenB);
+      });
+    });
+
+    // TODO: add some more tests for when the ratio changes. But first, we need to re-think the whole ratio deal when we understand better how to integrate with oracles
+  });
+
+  async function deposit(pairAddress: string, amountTokenA: number, amountTokenB: number) {
+    const tx: TransactionResponse = await MAPPositionHandler.deposit(pairAddress, tokenA.asUnits(amountTokenA), tokenB.asUnits(amountTokenB));
+    const positionId = await readArgFromEventOrFail<BigNumber>(tx, 'Deposited', '_positionId');
+    const shares = await readArgFromEventOrFail<BigNumber>(tx, 'Deposited', '_shares');
+    return { tx, positionId, shares };
+  }
+
+  function getLiquidityWithRatio({ amountTokenA, amountTokenB, ratio }: { amountTokenA: number; amountTokenB: number; ratio: number }) {
+    return tokenA.asUnits(amountTokenA).mul(ratio).add(tokenB.asUnits(amountTokenB));
+  }
+
+  async function expectBalanceToBe(token: TokenContract, address: string, amount: string | number) {
+    const balance = await token.balanceOf(address);
+    expect(balance).to.be.equal(token.asUnits(amount));
+  }
+
+  async function expectPositionToBe(
+    positionId: BigNumber,
+    {
+      shares: expectedShares,
+      ratioTokenB: expectedRatioTokenB,
+    }: {
+      shares: BigNumber;
+      ratioTokenB: BigNumber;
+    }
+  ) {
+    const { pair, ratioB, shares } = await MAPPositionHandler.positions(positionId);
+    expect(pair, 'Wrong pair').to.equal(PAIR_ADDRESS);
+    expect(shares, 'Wrong position shares').to.equal(expectedShares);
+    expect(ratioB, 'Wrong token B ratio').to.equal(expectedRatioTokenB);
+  }
+});


### PR DESCRIPTION
# Multi Asymmetric Pool
This PR introduces the concept of a `MultiAsymmetricPool`.

This type of pool is similar to other pair liquidity pools, but there are two main difference. First, this pool supports many different pairs at the same time, all in the same smart contract. Also, each pair allows liquidity providers to deposit any amount of one (or both) of the tokens involved. A direct consequence of this approach is that the price of the tokens involved is not determined by the ratio between them, and no arbitrage is needed. But, in order for everything to to work, an oracle must be used.

## So how does the pool work? 
When a user deposits any tokens, they are assigned some "shares", based on the value they contributed to the pool. The pool will the be used for trades, and it will gain some rewards as fees. When a liquidity provider then wants to withdraw their liquidity, they will get the percentage that belongs to them, based on the shares initially assigned.

### An example
Let's explain how it works with an example. Let's say that the pool has the following pair: ETH-DAI, and let's also say that the pair has 2 ETH and 1000 DAI deposited, and that the amount of existing shares for that pair is 1400.

If a user were to deposit 2 ETH into the pair-pool, and the price were 1 ETH = 200 DAI, then the total liquidity would be 4 ETH, and 1000 DAI. And the user would get 400 shares assigned. 

**How was this calculated?**
When a user makes a deposit or withdraw, it's important to determine the total amount of liquidity on the pool, and also the deposit. In order to do so, and since there is no relation between amount of tokens and price, each pair will have a "base token" assigned. In this case, let's say it is DAI. So in order to calculate the liquidity of the pool, we would do:
```
liquidity = amount(ETH) * ratio(ETH-to-DAI) + amount(DAI)
```

So going back to the example above, we had 2 ETH and 1000 DAI deposited. At `1 ETH = 200 DAI`, that's 1400 DAI of liquidity. Since there were 1400 shares, and the user added 400 DAI of liquidity, they get 400 shares.

And the same thing happens during withdraw. Let's asume that the amount of tokens in the pool remains the same, but now `1 ETH = 100 DAI`. The total liquidity of the pool is 
```
liquidity = 4 ETH * 100 DAI/ETH + 1000 DAI = 1400 DAI
```

The user who deposited the 2 ETH had 400 shares, so they can withdraw `1400 DAI * 400 / 1800 = 311.11 DAI = 3.11 ETH`

#### Withdraws
In order to prevent liquidity providers from using the pool to trade one token for the other without fees, we will honor the ratio of deposited tokens. That means, if someone deposited 100% ETH, then we will return their value in 100% ETH. If they deposited 50%-50%, we will return 50-50%. If it's not possible to return the respective amount of one of the respective tokens, then we will return the difference on the other one.

#### Can this be played?
Well, it depends on what you mean by played. If we look at the example above, you would see that someone entered the pool with 2 ETH and left with 3.11 ETH. It definitely looks weird, but it is expected. 

It's almost guaranteed to happen that the price changes between the tokens in the pair. When that happens, this approach benefits those who deposited the token that lost value, and is detrimental to those who deposited the token that gained value. In the example above, people who deposited DAI would have been better holding, that depositing into the pool. And people that deposited ETH were benefited, since they gained more ETH (although one could argue that they should have traded their ETH into DAI).


## This PR
This PR introduces the MultiAsymmetricPool, with some basic operations such as `deposit` and `calculateOwned`. There are still a few things to iron out, but the core structure is there
