### PR TITLE
refactor: rename to a & b

### DIFF
--- a/contracts/DCAFactory/DCAFactoryPairsHandler.sol
+++ b/contracts/DCAFactory/DCAFactoryPairsHandler.sol
@@ -8,7 +8,7 @@ import '../interfaces/IDCAGlobalParameters.sol';
 import '../libraries/CommonErrors.sol';
 
 abstract contract DCAFactoryPairsHandler is IDCAFactoryPairsHandler {
-  mapping(address => mapping(address => address)) internal _pairByTokens; // token0 => token1 => pair
+  mapping(address => mapping(address => address)) internal _pairByTokens; // tokenA => tokenB => pair
   address[] public override allPairs;
   IDCAGlobalParameters public override globalParameters;
 
@@ -17,23 +17,23 @@ abstract contract DCAFactoryPairsHandler is IDCAFactoryPairsHandler {
     globalParameters = _globalParameters;
   }
 
-  function _sortTokens(address _tokenA, address _tokenB) internal pure returns (address _token0, address _token1) {
-    (_token0, _token1) = _tokenA < _tokenB ? (_tokenA, _tokenB) : (_tokenB, _tokenA);
+  function _sortTokens(address _tokenA, address _tokenB) internal pure returns (address __tokenA, address __tokenB) {
+    (__tokenA, __tokenB) = _tokenA < _tokenB ? (_tokenA, _tokenB) : (_tokenB, _tokenA);
   }
 
   function pairByTokens(address _tokenA, address _tokenB) external view override returns (address _pair) {
-    (address _token0, address _token1) = _sortTokens(_tokenA, _tokenB);
-    _pair = _pairByTokens[_token0][_token1];
+    (address __tokenA, address __tokenB) = _sortTokens(_tokenA, _tokenB);
+    _pair = _pairByTokens[__tokenA][__tokenB];
   }
 
   function createPair(address _tokenA, address _tokenB) public override returns (address _pair) {
     if (_tokenA == address(0) || _tokenB == address(0)) revert CommonErrors.ZeroAddress();
     if (_tokenA == _tokenB) revert IdenticalTokens();
-    (address _token0, address _token1) = _sortTokens(_tokenA, _tokenB);
-    if (_pairByTokens[_token0][_token1] != address(0)) revert PairAlreadyExists();
-    _pair = address(new DCAPair(globalParameters, ISlidingOracle(address(0xe)), IERC20Detailed(_token0), IERC20Detailed(_token1)));
-    _pairByTokens[_token0][_token1] = _pair;
+    (address __tokenA, address __tokenB) = _sortTokens(_tokenA, _tokenB);
+    if (_pairByTokens[__tokenA][__tokenB] != address(0)) revert PairAlreadyExists();
+    _pair = address(new DCAPair(globalParameters, ISlidingOracle(address(0xe)), IERC20Detailed(__tokenA), IERC20Detailed(__tokenB)));
+    _pairByTokens[__tokenA][__tokenB] = _pair;
     allPairs.push(_pair);
-    emit PairCreated(_token0, _token1, _pair);
+    emit PairCreated(__tokenA, __tokenB, _pair);
   }
 }

--- a/contracts/interfaces/IDCAFactory.sol
+++ b/contracts/interfaces/IDCAFactory.sol
@@ -8,7 +8,7 @@ interface IDCAFactoryPairsHandler {
 
   error PairAlreadyExists();
 
-  event PairCreated(address indexed _token0, address indexed _token1, address _pair);
+  event PairCreated(address indexed _tokenA, address indexed _tokenB, address _pair);
 
   function globalParameters() external view returns (IDCAGlobalParameters);
 

--- a/contracts/mocks/DCAFactory/DCAFactoryPairsHandler.sol
+++ b/contracts/mocks/DCAFactory/DCAFactoryPairsHandler.sol
@@ -7,7 +7,7 @@ import '../../DCAFactory/DCAFactoryPairsHandler.sol';
 contract DCAFactoryPairsHandlerMock is DCAFactoryPairsHandler {
   constructor(IDCAGlobalParameters _globalParameters) DCAFactoryPairsHandler(_globalParameters) {}
 
-  function sortTokens(address _tokenA, address _tokenB) public pure returns (address _token0, address _token1) {
-    (_token0, _token1) = _sortTokens(_tokenA, _tokenB);
+  function sortTokens(address _tokenA, address _tokenB) public pure returns (address __tokenA, address __tokenB) {
+    (__tokenA, __tokenB) = _sortTokens(_tokenA, _tokenB);
   }
 }

--- a/contracts/mocks/DCAPair/DCAPairLoanHandler.sol
+++ b/contracts/mocks/DCAPair/DCAPairLoanHandler.sol
@@ -6,8 +6,8 @@ import './DCAPairParameters.sol';
 
 contract DCAPairLoanHandlerMock is DCAPairLoanHandler, DCAPairParametersMock {
   constructor(
-    IERC20Detailed _token0,
-    IERC20Detailed _token1,
+    IERC20Detailed _tokenA,
+    IERC20Detailed _tokenB,
     IDCAGlobalParameters _globalParameters
-  ) DCAPairParametersMock(_globalParameters, _token0, _token1) {}
+  ) DCAPairParametersMock(_globalParameters, _tokenA, _tokenB) {}
 }

--- a/contracts/mocks/DCAPair/DCAPairSwapHandler.sol
+++ b/contracts/mocks/DCAPair/DCAPairSwapHandler.sol
@@ -14,11 +14,11 @@ contract DCAPairSwapHandlerMock is DCAPairSwapHandler, DCAPairParametersMock {
   uint8 private _swapsToPerformLength;
 
   constructor(
-    IERC20Detailed _token0,
-    IERC20Detailed _token1,
+    IERC20Detailed _tokenA,
+    IERC20Detailed _tokenB,
     IDCAGlobalParameters _globalParameters,
     ISlidingOracle _oracle
-  ) DCAPairParametersMock(_globalParameters, _token0, _token1) DCAPairSwapHandler(_oracle) {
+  ) DCAPairParametersMock(_globalParameters, _tokenA, _tokenB) DCAPairSwapHandler(_oracle) {
     /* */
   }
 


### PR DESCRIPTION
For consistency, we are renaming `token0` & `token1` to `tokenA` and `tokenB`