### PR TITLE
feat: adding Swapper

### DIFF
--- a/contracts/DCASwapper/DCASwapper.sol
+++ b/contracts/DCASwapper/DCASwapper.sol
@@ -9,13 +9,16 @@ import '../libraries/CommonErrors.sol';
 contract DCASwapper is IDCASwapper, Governable {
   using EnumerableSet for EnumerableSet.AddressSet;
 
+  IDCAFactory public immutable override factory;
   EnumerableSet.AddressSet internal _watchedPairs;
 
-  constructor(address _governor) Governable(_governor) {}
+  constructor(address _governor, IDCAFactory _factory) Governable(_governor) {
+    factory = _factory;
+  }
 
   function startWatchingPairs(address[] calldata _pairs) public override onlyGovernor {
     for (uint256 i; i < _pairs.length; i++) {
-      if (_pairs[i] == address(0)) revert CommonErrors.ZeroAddress();
+      if (!factory.isPair(_pairs[i])) revert InvalidPairAddress();
       _watchedPairs.add(_pairs[i]);
     }
     emit WatchingNewPairs(_pairs);

--- a/contracts/interfaces/IDCASwapper.sol
+++ b/contracts/interfaces/IDCASwapper.sol
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.4;
 
+import '../interfaces/IDCAFactory.sol';
+
 interface IDCASwapper {
   event WatchingNewPairs(address[] _pairs);
   event StoppedWatchingPairs(address[] _pairs);
 
+  error InvalidPairAddress();
+
   /* Public getters */
   function watchedPairs() external view returns (address[] memory);
+
+  function factory() external view returns (IDCAFactory);
 
   /* Public setters */
   function startWatchingPairs(address[] calldata) external;

--- a/contracts/mocks/DCASwapper/DCAFactoryMock.sol
+++ b/contracts/mocks/DCASwapper/DCAFactoryMock.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.4;
+
+contract DCAFactoryMock {
+  mapping(address => bool) private _pairs;
+
+  function isPair(address _address) public view returns (bool _isPair) {
+    _isPair = _pairs[_address];
+  }
+
+  function setAsPair(address _address) public {
+    _pairs[_address] = true;
+  }
+}

--- a/contracts/mocks/DCASwapper/DCASwapper.sol
+++ b/contracts/mocks/DCASwapper/DCASwapper.sol
@@ -5,5 +5,5 @@ pragma solidity 0.8.4;
 import '../../DCASwapper/DCASwapper.sol';
 
 contract DCASwapperMock is DCASwapper {
-  constructor(address _governor) DCASwapper(_governor) {}
+  constructor(address _governor, IDCAFactory _factory) DCASwapper(_governor, _factory) {}
 }


### PR DESCRIPTION
We are now adding a new contract. This contract will have the job of executing swaps in our pairs. It will do so by taking the exceeding tokens, selling them on the market, and returning them to the pair.

This is the first step in the contract, where we just have a list of pairs that this contract will be in charge of swapping.