### PR TITLE
feat: implement supportsPair

### DIFF
--- a/contracts/UniswapV3Oracle/UniswapV3Oracle.sol
+++ b/contracts/UniswapV3Oracle/UniswapV3Oracle.sol
@@ -17,9 +17,14 @@ contract UniswapV3Oracle is IUniswapV3OracleAggregator, Governable {
     factory = _factory;
   }
 
-  function supportsPair(address, address) external view override returns (bool _isPairSupported) {
-    // TODO
-    _isPairSupported = true;
+  function supportsPair(address _tokenA, address _tokenB) external view override returns (bool) {
+    uint256 _length = _supportedFeeTiers.length();
+    for (uint256 i; i < _length; i++) {
+      if (factory.getPool(_tokenA, _tokenB, uint24(_supportedFeeTiers.at(i))) != address(0)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   function quote(

--- a/contracts/mocks/UniswapV3Oracle/UniswapV3FactoryMock.sol
+++ b/contracts/mocks/UniswapV3Oracle/UniswapV3FactoryMock.sol
@@ -3,12 +3,30 @@ pragma solidity 0.8.4;
 
 contract UniswapV3FactoryMock {
   int24 private _tickSpacing;
+  mapping(address => mapping(address => mapping(uint24 => address))) private _pools;
 
   function feeAmountTickSpacing(uint24) external view returns (int24) {
     return _tickSpacing;
   }
 
+  function getPool(
+    address _tokenA,
+    address _tokenB,
+    uint24 _fee
+  ) external view returns (address _pool) {
+    _pool = _pools[_tokenA][_tokenB][_fee];
+  }
+
   function setTickSpacing(int24 __tickSpacing) public {
     _tickSpacing = __tickSpacing;
+  }
+
+  function setPool(
+    address _tokenA,
+    address _tokenB,
+    uint24 _fee,
+    address _pool
+  ) external {
+    _pools[_tokenA][_tokenB][_fee] = _pool;
   }
 }

--- a/test/unit/UniswapV3Oracle/uniswap-v3-oracle.spec.ts
+++ b/test/unit/UniswapV3Oracle/uniswap-v3-oracle.spec.ts
@@ -76,4 +76,37 @@ describe('UniswapV3Oracle', () => {
       governor: () => owner,
     });
   });
+
+  describe('supportsPair', () => {
+    const TOKEN_A = '0x0000000000000000000000000000000000000001';
+    const TOKEN_B = '0x0000000000000000000000000000000000000002';
+    const POOL = '0x0000000000000000000000000000000000000003';
+    const FEE = 1000;
+
+    when('no pool exists for pair', () => {
+      then('pair is not supported', async () => {
+        expect(await UniswapV3Oracle.supportsPair(TOKEN_A, TOKEN_B)).to.be.false;
+      });
+    });
+
+    when('pool exists for pair on unsupported fie tier', () => {
+      given(async () => {
+        await UniswapV3Factory.setPool(TOKEN_A, TOKEN_B, FEE, POOL);
+      });
+      then('pair is not supported', async () => {
+        expect(await UniswapV3Oracle.supportsPair(TOKEN_A, TOKEN_B)).to.be.false;
+      });
+    });
+
+    when('pool exists for pair on supported fie tier', () => {
+      given(async () => {
+        await UniswapV3Factory.setTickSpacing(1);
+        await UniswapV3Factory.setPool(TOKEN_A, TOKEN_B, FEE, POOL);
+        await UniswapV3Oracle.addFeeTier(FEE);
+      });
+      then('pair is marked as supported', async () => {
+        expect(await UniswapV3Oracle.supportsPair(TOKEN_A, TOKEN_B)).to.be.true;
+      });
+    });
+  });
 });


### PR DESCRIPTION
We are now implementing `supportsPair`. We will consider that the oracle will support a pair if there is at least one fee tier for it