### PR TITLE
fix: provide reward correctly on swap

### DIFF
--- a/contracts/DCAPair/DCAPairSwapHandler.sol
+++ b/contracts/DCAPair/DCAPairSwapHandler.sol
@@ -124,8 +124,9 @@ abstract contract DCAPairSwapHandler is ReentrancyGuard, DCAPairParameters, IDCA
       _nextSwapInformation.tokenToBeProvidedBySwapper = tokenB;
       _nextSwapInformation.tokenToRewardSwapperWith = tokenA;
       uint256 _tokenASurplus = _amountToSwapTokenA - _amountOfTokenAIfTokenBSwapped;
-      _nextSwapInformation.amountToBeProvidedBySwapper = _convertTo(_magnitudeA, _tokenASurplus, _nextSwapInformation.ratePerUnitAToB);
-      _nextSwapInformation.amountToRewardSwapperWith = _tokenASurplus + _getFeeFromAmount(_swapFee, _tokenASurplus);
+      uint256 _needed = _convertTo(_magnitudeA, _tokenASurplus, _nextSwapInformation.ratePerUnitAToB);
+      _nextSwapInformation.amountToBeProvidedBySwapper = _needed - _getFeeFromAmount(_swapFee, _needed);
+      _nextSwapInformation.amountToRewardSwapperWith = _tokenASurplus;
       _nextSwapInformation.platformFeeTokenA = _getFeeFromAmount(_swapFee, _amountOfTokenAIfTokenBSwapped);
       _nextSwapInformation.platformFeeTokenB = _getFeeFromAmount(_swapFee, _amountToSwapTokenB);
       _nextSwapInformation.availableToBorrowTokenA = _balances[address(tokenA)] - _nextSwapInformation.amountToRewardSwapperWith;
@@ -133,17 +134,12 @@ abstract contract DCAPairSwapHandler is ReentrancyGuard, DCAPairParameters, IDCA
     } else if (_amountOfTokenAIfTokenBSwapped > _amountToSwapTokenA) {
       _nextSwapInformation.tokenToBeProvidedBySwapper = tokenA;
       _nextSwapInformation.tokenToRewardSwapperWith = tokenB;
-      _nextSwapInformation.amountToBeProvidedBySwapper = _amountOfTokenAIfTokenBSwapped - _amountToSwapTokenA;
-      uint256 _amountToBeProvidedConvertedToB = _convertTo(
-        _magnitudeA,
-        _nextSwapInformation.amountToBeProvidedBySwapper,
-        _nextSwapInformation.ratePerUnitAToB
-      );
-      _nextSwapInformation.amountToRewardSwapperWith =
-        _amountToBeProvidedConvertedToB +
-        _getFeeFromAmount(_swapFee, _amountToBeProvidedConvertedToB);
+      uint256 _needed = _amountOfTokenAIfTokenBSwapped - _amountToSwapTokenA;
+      uint256 _neededConvertedToB = _convertTo(_magnitudeA, _needed, _nextSwapInformation.ratePerUnitAToB);
+      _nextSwapInformation.amountToBeProvidedBySwapper = _needed - _getFeeFromAmount(_swapFee, _needed);
+      _nextSwapInformation.amountToRewardSwapperWith = _neededConvertedToB;
       _nextSwapInformation.platformFeeTokenA = _getFeeFromAmount(_swapFee, _amountToSwapTokenA);
-      _nextSwapInformation.platformFeeTokenB = _getFeeFromAmount(_swapFee, _amountToSwapTokenB - _amountToBeProvidedConvertedToB);
+      _nextSwapInformation.platformFeeTokenB = _getFeeFromAmount(_swapFee, _amountToSwapTokenB - _neededConvertedToB);
       _nextSwapInformation.availableToBorrowTokenA = _balances[address(tokenA)];
       _nextSwapInformation.availableToBorrowTokenB = _balances[address(tokenB)] - _nextSwapInformation.amountToRewardSwapperWith;
     } else {


### PR DESCRIPTION
This change is best explained with an example. Let's say that there is a swap that is going to be executed, where
* 200 token A are being swapped
* 100 token B are being swapped
* 1 token A = 1 token B

So, we would need the swapper to provide 100 token B, and they would get 100 token A in exchange.

Now, before this change, we would:
* Request 100 token B
* Award the swapper with 100 token A + 0.3%

Now, we will:
* Request 100 token B - 0.3%
* Award the swapper with 100 token A
