### PR TITLE
fix: avoid exposing list of active swap intervals

### DIFF
--- a/contracts/DCAPair/DCAPairParameters.sol
+++ b/contracts/DCAPair/DCAPairParameters.sol
@@ -46,12 +46,8 @@ abstract contract DCAPairParameters is IDCAPairParameters {
     _magnitudeB = uint112(10**_tokenB.decimals());
   }
 
-  function activeSwapIntervals() external view override returns (uint32[] memory __activeSwapIntervals) {
-    uint256 _activeSwapIntervalsLength = _activeSwapIntervals.length();
-    __activeSwapIntervals = new uint32[](_activeSwapIntervalsLength);
-    for (uint256 i; i < _activeSwapIntervalsLength; i++) {
-      __activeSwapIntervals[i] = uint32(_activeSwapIntervals.at(i));
-    }
+  function isSwapIntervalActive(uint32 _activeSwapInterval) external view override returns (bool _isIntervalActive) {
+    _isIntervalActive = _activeSwapIntervals.contains(_activeSwapInterval);
   }
 
   function _getFeeFromAmount(uint32 _feeAmount, uint256 _amount) internal view returns (uint256) {

--- a/contracts/interfaces/IDCAPair.sol
+++ b/contracts/interfaces/IDCAPair.sol
@@ -18,7 +18,7 @@ interface IDCAPairParameters {
     uint32
   ) external view returns (int256);
 
-  function activeSwapIntervals() external view returns (uint32[] memory);
+  function isSwapIntervalActive(uint32) external view returns (bool);
 
   function performedSwaps(uint32) external view returns (uint32);
 }

--- a/test/unit/DCAFactory/dca-factory-pairs-handler.spec.ts
+++ b/test/unit/DCAFactory/dca-factory-pairs-handler.spec.ts
@@ -6,7 +6,7 @@ import { constants, erc20, behaviours } from '../../utils';
 import { given, then, when } from '../../utils/bdd';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signers';
 
-describe.skip('DCAFactoryPairsHandler', function () {
+describe('DCAFactoryPairsHandler', function () {
   let owner: SignerWithAddress;
   let tokenAContract: Contract, tokenBContract: Contract;
   let DCAGlobalParametersContract: ContractFactory, DCAFactoryPairsHandlerContract: ContractFactory;

--- a/test/unit/DCAPair/dca-pair-parameters.spec.ts
+++ b/test/unit/DCAPair/dca-pair-parameters.spec.ts
@@ -105,9 +105,6 @@ describe('DCAPairParameters', function () {
       then('fee precision is copied from global parameters', async () => {
         expect(await deployedContract.feePrecision()).to.equal(await DCAGlobalParameters.FEE_PRECISION());
       });
-      then('active swap intervals starts empty', async () => {
-        expect(await deployedContract.activeSwapIntervals()).to.be.empty;
-      });
     });
   });
 

--- a/test/unit/DCAPair/dca-pair-position-handler.spec.ts
+++ b/test/unit/DCAPair/dca-pair-position-handler.spec.ts
@@ -222,8 +222,8 @@ describe('DCAPositionHandler', () => {
         expect(balance).to.equal(1);
       });
 
-      then('interval is added to active list', async () => {
-        expect(await DCAPositionHandler.activeSwapIntervals()).to.eql([SWAP_INTERVAL]);
+      then('interval is now active', async () => {
+        expect(await DCAPositionHandler.isSwapIntervalActive(SWAP_INTERVAL)).to.be.true;
       });
 
       thenInternalBalancesAreTheSameAsTokenBalances();

--- a/test/unit/DCAPair/dca-pair-swap-handler.spec.ts
+++ b/test/unit/DCAPair/dca-pair-swap-handler.spec.ts
@@ -896,7 +896,10 @@ describe('DCAPairSwapHandler', () => {
         }
       });
       then('active swap intervals remain the same', async () => {
-        expect(await DCAPairSwapHandler.activeSwapIntervals()).to.eql([SWAP_INTERVAL].concat(addedSwapIntervals ?? []));
+        expect(await DCAPairSwapHandler.isSwapIntervalActive(SWAP_INTERVAL)).to.true;
+        for (const addedSwapInterval of addedSwapIntervals ?? []) {
+          expect(await DCAPairSwapHandler.isSwapIntervalActive(addedSwapInterval)).to.true;
+        }
       });
       thenInternalBalancesAreTheSameAsTokenBalances();
     });
@@ -1147,8 +1150,8 @@ describe('DCAPairSwapHandler', () => {
       then('performed swaps did not increase', async () => {
         expect(await DCAPairSwapHandler.performedSwaps(SWAP_INTERVAL)).to.equal(0);
       });
-      then('swap interval is removed from active list', async () => {
-        expect(await DCAPairSwapHandler.activeSwapIntervals()).to.be.empty;
+      then('swap interval is no longer active', async () => {
+        expect(await DCAPairSwapHandler.isSwapIntervalActive(SWAP_INTERVAL)).to.be.false;
       });
 
       thenInternalBalancesAreTheSameAsTokenBalances();
@@ -1356,7 +1359,8 @@ describe('DCAPairSwapHandler', () => {
       });
 
       then('active swap intervals remain the same', async () => {
-        expect(await DCAPairSwapHandler.activeSwapIntervals()).to.eql([SWAP_INTERVAL]);
+        expect(await DCAPairSwapHandler.isSwapIntervalActive(SWAP_INTERVAL)).to.be.true;
+        expect(await DCAPairSwapHandler.isSwapIntervalActive(SWAP_INTERVAL_2)).to.be.false;
       });
 
       thenInternalBalancesAreTheSameAsTokenBalances();
@@ -1836,7 +1840,10 @@ describe('DCAPairSwapHandler', () => {
       });
 
       then('active swap intervals remain the same', async () => {
-        expect(await DCAPairSwapHandler.activeSwapIntervals()).to.eql([SWAP_INTERVAL].concat(addedSwapIntervals ?? []));
+        expect(await DCAPairSwapHandler.isSwapIntervalActive(SWAP_INTERVAL)).to.true;
+        for (const addedSwapInterval of addedSwapIntervals ?? []) {
+          expect(await DCAPairSwapHandler.isSwapIntervalActive(addedSwapInterval)).to.true;
+        }
       });
 
       thenInternalBalancesAreTheSameAsTokenBalances(threshold as BigNumber);


### PR DESCRIPTION
We are now changing from `activeSwapIntervals` to `isSwapIntervalActive` to reduce the contract's size. There wasn't a good use case to list all active swap intervals in the first place, so no harm there.