### PR TITLE
refactor: make get pairs to swap a view

### DIFF
--- a/contracts/DCASwapper/DCASwapper.sol
+++ b/contracts/DCASwapper/DCASwapper.sol
@@ -56,10 +56,10 @@ contract DCASwapper is IDCASwapper, Governable, IDCAPairSwapCallee {
   }
 
   /**
-   * This method isn't a view and it is extremelly expensive and inefficient.
+   * This method isn't really a view and it is extremelly expensive and inefficient.
    * DO NOT call this method on-chain, it is for off-chain purposes only.
    */
-  function getPairsToSwap() external override returns (IDCAPair[] memory _pairs, uint24[] memory _bestFeeTiers) {
+  function getPairsToSwap() external view override returns (IDCAPair[] memory _pairs, uint24[] memory _bestFeeTiers) {
     uint256 _count;
 
     // Count how many pairs can be swapped
@@ -107,11 +107,11 @@ contract DCASwapper is IDCASwapper, Governable, IDCAPairSwapCallee {
   }
 
   /**
-   * This method isn't a view because the Uniswap quoter doesn't support view quotes.
+   * This method isn't really a view because the Uniswap quoter doesn't support view quotes.
    * Therefore, we highly recommend that this method is not called on-chain.
    * This method will return 0 if the pair should not be swapped, and max(uint24) if there is no need to go to Uniswap
    */
-  function _bestFeeTierForSwap(IDCAPair _pair) internal virtual returns (uint24 _feeTier) {
+  function _bestFeeTierForSwap(IDCAPair _pair) internal view virtual returns (uint24 _feeTier) {
     IDCAPairSwapHandler.NextSwapInformation memory _nextSwapInformation = _pair.getNextSwapInfo();
     if (_nextSwapInformation.amountOfSwaps == 0) {
       return 0;

--- a/contracts/interfaces/IDCASwapper.sol
+++ b/contracts/interfaces/IDCASwapper.sol
@@ -2,11 +2,25 @@
 pragma solidity 0.8.4;
 
 import '@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol';
-import '@uniswap/v3-periphery/contracts/interfaces/IQuoter.sol';
 import '@uniswap/v3-periphery/contracts/interfaces/IPeripheryImmutableState.sol';
 import '../interfaces/IDCAFactory.sol';
 
-interface ICustomQuoter is IQuoter, IPeripheryImmutableState {}
+interface ICustomQuoter is IPeripheryImmutableState {
+  /// @notice Returns the amount in required to receive the given exact output amount but for a swap of a single pool
+  /// @param tokenIn The token being swapped in
+  /// @param tokenOut The token being swapped out
+  /// @param fee The fee of the token pool to consider for the pair
+  /// @param amountOut The desired output amount
+  /// @param sqrtPriceLimitX96 The price limit of the pool that cannot be exceeded by the swap
+  /// @return amountIn The amount required as the input for the swap in order to receive `amountOut`
+  function quoteExactOutputSingle(
+    address tokenIn,
+    address tokenOut,
+    uint24 fee,
+    uint256 amountOut,
+    uint160 sqrtPriceLimitX96
+  ) external view returns (uint256 amountIn);
+}
 
 interface IDCASwapper {
   event WatchingNewPairs(address[] _pairs);
@@ -26,10 +40,10 @@ interface IDCASwapper {
   function quoter() external view returns (ICustomQuoter);
 
   /**
-   * This method isn't a view and it is extremelly expensive and inefficient.
+   * This method isn't really a view and it is extremelly expensive and inefficient.
    * DO NOT call this method on-chain, it is for off-chain purposes only.
    */
-  function getPairsToSwap() external returns (IDCAPair[] memory _pairs, uint24[] memory _bestFeeTiers);
+  function getPairsToSwap() external view returns (IDCAPair[] memory _pairs, uint24[] memory _bestFeeTiers);
 
   /* Public setters */
   function startWatchingPairs(address[] calldata) external;

--- a/contracts/mocks/DCASwapper/DCASwapper.sol
+++ b/contracts/mocks/DCASwapper/DCASwapper.sol
@@ -18,11 +18,11 @@ contract DCASwapperMock is DCASwapper {
     ICustomQuoter _quoter
   ) DCASwapper(_governor, _factory, _router, _quoter) {}
 
-  function bestFeeTierForSwap(IDCAPair _pair) external returns (uint24 _feeTier) {
+  function bestFeeTierForSwap(IDCAPair _pair) external view returns (uint24 _feeTier) {
     _feeTier = _bestFeeTierForSwap(_pair);
   }
 
-  function _bestFeeTierForSwap(IDCAPair _pair) internal override returns (uint24 _feeTier) {
+  function _bestFeeTierForSwap(IDCAPair _pair) internal view override returns (uint24 _feeTier) {
     if (_pairsToSwapSet) {
       _feeTier = _pairsToSwap[address(_pair)];
     } else {


### PR DESCRIPTION
We are now making `getPairsToSwap` a view, when it really isn't. This is to try to trick Etherscan into making static calls into the method, and allow calling it directly on the interface. 