### PR TITLE
perf: avoid sending 0 tokens

### DIFF
--- a/contracts/DCAPair/DCAPairParameters.sol
+++ b/contracts/DCAPair/DCAPairParameters.sol
@@ -15,9 +15,9 @@ abstract contract DCAPairParameters is IDCAPairParameters {
   using EnumerableSet for EnumerableSet.UintSet;
 
   // Internal constants
-  uint112 internal immutable _magnitudeA;
-  uint112 internal immutable _magnitudeB;
-  uint24 internal immutable _feePrecision;
+  uint112 internal _magnitudeA;
+  uint112 internal _magnitudeB;
+  uint24 internal _feePrecision;
 
   // Basic setup
   IDCAGlobalParameters public override globalParameters;

--- a/contracts/DCAPair/DCAPairSwapHandler.sol
+++ b/contracts/DCAPair/DCAPairSwapHandler.sol
@@ -265,8 +265,10 @@ abstract contract DCAPairSwapHandler is ReentrancyGuard, DCAPairParameters, IDCA
     _balances[address(tokenB)] = _finalAmountToHaveTokenB;
 
     // Send fees and extra
-    tokenA.safeTransfer(_swapParameters.feeRecipient, _balanceTokenA - _finalAmountToHaveTokenA);
-    tokenB.safeTransfer(_swapParameters.feeRecipient, _balanceTokenB - _finalAmountToHaveTokenB);
+    uint256 _toFeeRecipientTokenA = _balanceTokenA - _finalAmountToHaveTokenA;
+    uint256 _toFeeRecipientTokenB = _balanceTokenB - _finalAmountToHaveTokenB;
+    if (_toFeeRecipientTokenA > 0) tokenA.safeTransfer(_swapParameters.feeRecipient, _toFeeRecipientTokenA);
+    if (_toFeeRecipientTokenB > 0) tokenB.safeTransfer(_swapParameters.feeRecipient, _toFeeRecipientTokenB);
 
     // Emit event
     emit Swapped(msg.sender, _to, _amountToBorrowTokenA, _amountToBorrowTokenB, _swapParameters.swapFee, _nextSwapInformation);


### PR DESCRIPTION
We are now avoiding sending 0 tokens on `swap`