### PR TITLE
refactor: remove die

### DIFF
--- a/contracts/DCASwapper/DCASwapper.sol
+++ b/contracts/DCASwapper/DCASwapper.sol
@@ -118,10 +118,6 @@ contract DCASwapper is IDCASwapper, Governable, IDCAPairSwapCallee, CollectableD
     _unpause();
   }
 
-  function die(address _to) external override onlyGovernor {
-    selfdestruct(payable(_to));
-  }
-
   /**
    * This method isn't a view because the Uniswap quoter doesn't support view quotes.
    * Therefore, we highly recommend that this method is not called on-chain.

--- a/contracts/interfaces/IDCASwapper.sol
+++ b/contracts/interfaces/IDCASwapper.sol
@@ -56,8 +56,6 @@ interface IDCASwapper is ICollectableDust {
    */
   function swapPairs(PairToSwap[] calldata _pairsToSwap) external returns (uint256 _amountSwapped);
 
-  function die(address _to) external;
-
   function pause() external;
 
   function unpause() external;

--- a/test/unit/DCASwapper/dca-swapper.spec.ts
+++ b/test/unit/DCASwapper/dca-swapper.spec.ts
@@ -577,23 +577,6 @@ describe('DCASwapper', () => {
       });
     });
   });
-  describe('die', () => {
-    when('die is called', () => {
-      given(async () => {
-        await DCASwapper.die(ADDRESS_1);
-      });
-      then('contract self destructs', async () => {
-        const code = await ethers.provider.getCode(DCASwapper.address);
-        expect(code).to.equal('0x');
-      });
-    });
-    behaviours.shouldBeExecutableOnlyByGovernor({
-      contract: () => DCASwapper,
-      funcAndSignature: 'die(address)',
-      params: [ADDRESS_1],
-      governor: () => owner,
-    });
-  });
   describe('sendDust', () => {
     let token: TokenContract;
     given(async () => {


### PR DESCRIPTION
Since we can pause the swapper now, we have no need to make it selfdestruct