### PR TITLE
fix: dont support pools with no liquidity

### DIFF
--- a/contracts/interfaces/ITimeWeightedOracle.sol
+++ b/contracts/interfaces/ITimeWeightedOracle.sol
@@ -42,6 +42,9 @@ interface IUniswapV3OracleAggregator is ITimeWeightedOracle {
   // solhint-disable-next-line func-name-mixedcase
   function MAXIMUM_PERIOD() external view returns (uint16);
 
+  // solhint-disable-next-line func-name-mixedcase
+  function MINIMUM_LIQUIDITY_THRESHOLD() external view returns (uint16);
+
   /* Public setters */
   function addFeeTier(uint24) external;
 

--- a/contracts/mocks/UniswapV3Oracle/UniswapV3PoolMock.sol
+++ b/contracts/mocks/UniswapV3Oracle/UniswapV3PoolMock.sol
@@ -3,9 +3,18 @@ pragma solidity 0.8.4;
 
 contract UniswapV3PoolMock {
   uint16 public cardinalitySent;
+  uint16 private _liquidity = 1;
 
   function increaseObservationCardinalityNext(uint16 _cardinality) external {
     cardinalitySent = _cardinality;
+  }
+
+  function liquidity() external view returns (uint128) {
+    return _liquidity;
+  }
+
+  function setLiquidity(uint16 __liquidity) external {
+    _liquidity = __liquidity;
   }
 
   function reset() external {


### PR DESCRIPTION
Since pools with no liquidity can't be used as oracles, we are now failing on our oracle when someone tries to add support for a pair that only has pools with no liquidity