### PR TITLE
feat: add support for configuring a delay

### DIFF
--- a/contracts/DCAKeep3rJob/DCAKeep3rJob.sol
+++ b/contracts/DCAKeep3rJob/DCAKeep3rJob.sol
@@ -16,6 +16,7 @@ contract DCAKeep3rJob is IDCAKeep3rJob, Governable {
   IDCAFactory public immutable override factory;
   IDCASwapper public override swapper;
   IKeep3rV1 public override keep3rV1;
+  mapping(uint32 => uint32) internal _delay; // swap interval => delay
   EnumerableSet.AddressSet internal _subsidizedPairs;
 
   constructor(
@@ -63,6 +64,18 @@ contract DCAKeep3rJob is IDCAKeep3rJob, Governable {
     _pairs = new address[](_length);
     for (uint256 i; i < _length; i++) {
       _pairs[i] = _subsidizedPairs.at(i);
+    }
+  }
+
+  function setDelay(uint32 _swapInterval, uint32 __delay) external override onlyGovernor {
+    _delay[_swapInterval] = __delay;
+    emit DelaySet(_swapInterval, __delay);
+  }
+
+  function delay(uint32 _swapInterval) external view override returns (uint32 __delay) {
+    __delay = _delay[_swapInterval];
+    if (__delay == 0) {
+      __delay = _swapInterval / 2;
     }
   }
 

--- a/contracts/interfaces/IDCAKeep3rJob.sol
+++ b/contracts/interfaces/IDCAKeep3rJob.sol
@@ -11,6 +11,7 @@ interface IDCAKeep3rJob {
   event SwapperSet(IDCASwapper _swapper);
   event Keep3rV1Set(IKeep3rV1 _keep3rV1);
   event Worked(uint256 _amountSwapped);
+  event DelaySet(uint32 _swapInterval, uint32 _delay);
 
   error InvalidPairAddress();
   error PairNotSubsidized();
@@ -24,6 +25,8 @@ interface IDCAKeep3rJob {
   function factory() external view returns (IDCAFactory);
 
   function swapper() external view returns (IDCASwapper);
+
+  function delay(uint32 _swapInterval) external view returns (uint32 _delay);
 
   /**
    * This method isn't a view and it is extremelly expensive and inefficient.
@@ -39,6 +42,8 @@ interface IDCAKeep3rJob {
   function startSubsidizingPairs(address[] calldata) external;
 
   function stopSubsidizingPairs(address[] calldata) external;
+
+  function setDelay(uint32 _swapInterval, uint32 _delay) external;
 
   /**
    * Takes an array of swaps, and executes as many as possible, returning the amount that was swapped

--- a/test/unit/DCAKeep3rJob/dca-keep3r-job.spec.ts
+++ b/test/unit/DCAKeep3rJob/dca-keep3r-job.spec.ts
@@ -210,6 +210,48 @@ describe('DCAKeep3rJob', () => {
     });
   });
 
+  describe('setDelay', () => {
+    const SWAP_INTERVAL = 10;
+    when('delay is set', () => {
+      let tx: TransactionResponse;
+
+      given(async () => {
+        tx = await DCAKeep3rJob.setDelay(SWAP_INTERVAL, 50);
+      });
+
+      then('event is emitted', async () => {
+        await expect(tx).to.emit(DCAKeep3rJob, 'DelaySet').withArgs(SWAP_INTERVAL, 50);
+      });
+      then('the contract reports it so', async () => {
+        expect(await DCAKeep3rJob.delay(SWAP_INTERVAL)).to.equal(50);
+      });
+    });
+    behaviours.shouldBeExecutableOnlyByGovernor({
+      contract: () => DCAKeep3rJob,
+      funcAndSignature: 'setDelay',
+      params: [SWAP_INTERVAL, 50],
+      governor: () => owner,
+    });
+  });
+
+  describe('delay', () => {
+    const SWAP_INTERVAL = 10;
+    when('delay is set', () => {
+      given(async () => {
+        await DCAKeep3rJob.setDelay(SWAP_INTERVAL, 50);
+      });
+
+      then('the set value is reported correctly', async () => {
+        expect(await DCAKeep3rJob.delay(SWAP_INTERVAL)).to.equal(50);
+      });
+    });
+    when('no delay is set', () => {
+      then('the returned value is half of the interval', async () => {
+        expect(await DCAKeep3rJob.delay(SWAP_INTERVAL)).to.equal(SWAP_INTERVAL / 2);
+      });
+    });
+  });
+
   describe('workable', () => {
     const ADDRESS_3 = '0x0000000000000000000000000000000000000003';
 


### PR DESCRIPTION
We are now adding support for configuring a delay on our Keeper Job. The idea is that the job will only be able to execute a swap after the window opened and the configured delay has passed.

If no delay was configured, then the default will be half of the internal.